### PR TITLE
Chore: tailwind default theme 적용

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules
 craco.config.js
+tailwind.config.js

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 /** @type {import('tailwindcss').Config} */
+const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
@@ -14,7 +15,7 @@ module.exports = {
         '3xl': '1.875rem',
       },
       fontFamily: {
-        Pretendard: ['Pretendard', 'sans-serif'],
+        Pretendard: ['Pretendard', ...defaultTheme.fontFamily.sans],
       },
       boxShadow: {
         sm: '0px 4px 6px -2px rgba(0, 0, 0, 0.05)',


### PR DESCRIPTION
## 💻 작업 개요

<!--
ex) 구글 소셜 로그인 기능 추가
-->

- 테일윈드 폰트 defaultFamily 적용

## 💡 변경 사항 (PR 내용)

<!--
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
-->

-

## 🧐 참고 사항

<!--
리뷰 시 유의할 점, 생각해볼 문제
-->

- defaultTheme import할때 lint 잡혀서 ignore에 추가했습니다.

## 🖼️ 스크린샷

<!--
스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수 있습니다. 스크린샷을 권장합니다.
![image](경로)
-->
적용 전
![SCR-20240729-uabf](https://github.com/user-attachments/assets/d4a68f10-f1ba-40b0-b544-9bb052215512)
적용 후
<img width="262" alt="SCR-20240729-ualx" src="https://github.com/user-attachments/assets/302770a0-f30f-4279-85fe-784ca6acc02f">

기존의 Pretendard와 sans-serif만 적용됐던것을 defaultTheme을 이용해 다양한 브라우저 환경과의 호환성을 높였습니다.

## ️✅ 체크리스트 (PR 올리기 전 아래 내용을 확인해 주세요)

- [x] Reviewers를 지정해주세요
- [x] Assignees는 본인을 선택해주세요
- [x] label을 선택해주세요
