### PR TITLE
[Kan-44] Feature: note 생성 페이지 퍼블리싱

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,9 @@ function App() {
   const { pathname } = useLocation();
 
   const bgColor =
-    pathname === '/sign-in' || pathname === '/sign-up'
+    pathname === '/sign-in' ||
+    pathname === '/sign-up' ||
+    pathname === '/notes/new'
       ? 'bg-white'
       : 'bg-slate-200';
 

--- a/src/pages/NewNote/components/TextEditor/Toolbar.tsx
+++ b/src/pages/NewNote/components/TextEditor/Toolbar.tsx
@@ -21,7 +21,7 @@ function Toolbar({ editor }: ToolbarProps) {
   const DEFAULT_FILL_COLOR = 'fill-slate-700';
 
   return (
-    <div className="flex justify-between rounded-[21.5px] border border-slate-200 bg-white px-4 py-[10px] shadow-xs">
+    <div className="fixed bottom-6 z-10 flex w-full max-w-[792px] justify-between rounded-[21.5px] border border-slate-200 bg-white px-4 py-[10px] shadow-xs">
       <div className="flex gap-4">
         <div className="flex gap-1">
           <BoldIcon

--- a/src/pages/NewNote/components/TextEditor/index.css
+++ b/src/pages/NewNote/components/TextEditor/index.css
@@ -113,6 +113,10 @@
   padding-left: 1rem;
 }
 
+.ProseMirror {
+  padding-bottom: 80px;
+}
+
 .ProseMirror-focused {
   outline: none;
 }

--- a/src/pages/NewNote/components/TextEditor/index.tsx
+++ b/src/pages/NewNote/components/TextEditor/index.tsx
@@ -9,10 +9,15 @@ import Typography from '@tiptap/extension-typography';
 import Underline from '@tiptap/extension-underline';
 import { EditorContent, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
+import { useEffect } from 'react';
 import Toolbar from './Toolbar';
 import './index.css';
 
-function TextEditor() {
+interface TextEditorProps {
+  onContentChange: (text: string, content: string) => void;
+}
+
+function TextEditor({ onContentChange }: TextEditorProps) {
   const editor = useEditor({
     extensions: [
       StarterKit,
@@ -24,14 +29,35 @@ function TextEditor() {
       TaskList,
       TaskItem.configure({ nested: true }),
       TextAlign.configure({ types: ['paragraph'] }),
-      Placeholder.configure({ placeholder: '이곳에 내용을 작성하세요.' }),
+      Placeholder.configure({
+        placeholder: '이 곳을 클릭해 노트 작성을 시작해주세요',
+      }),
     ],
   });
 
+  useEffect(() => {
+    if (!editor) return undefined;
+
+    const handleUpdate = () => {
+      const text = editor.getText();
+      const content = editor.getHTML();
+      onContentChange(text, content);
+    };
+
+    editor.on('update', handleUpdate);
+
+    return () => {
+      editor.off('update', handleUpdate);
+    };
+  }, [editor, onContentChange]);
+
   return (
-    <div>
+    <div className="mb-8 flex-grow">
       {editor && <Toolbar editor={editor} />}
-      <EditorContent editor={editor} className="bg-white text-slate-700" />
+      <EditorContent
+        editor={editor}
+        className="overflow-auto bg-white text-slate-700"
+      />
     </div>
   );
 }

--- a/src/pages/NewNote/index.tsx
+++ b/src/pages/NewNote/index.tsx
@@ -1,9 +1,124 @@
+import { FlagIcon } from '@assets';
+import Button from '@components/Button';
+import { ChangeEvent, useState } from 'react';
 import TextEditor from './components/TextEditor';
 
+const MOCK_TODO = {
+  noteId: 0,
+  done: true,
+  linkUrl: 'string',
+  fileUrl: 'string',
+  title: '투두입니당',
+  id: 0,
+  goal: {
+    id: 0,
+    title: '목표입니다',
+  },
+  userId: 0,
+  teamId: 'string',
+  updatedAt: '2024-08-01T05:23:51.630Z',
+  createdAt: '2024-08-01T05:23:51.630Z',
+};
+
+const TITLE_MAX_LENGTH = 30;
+
 function NewNotePage() {
+  const [titleCount, setTitleCount] = useState(0);
+  const [contentWithSpaces, setContentWithSpaces] = useState(0);
+  const [contentWithoutSpaces, setContentWithoutSpaces] = useState(0);
+  const [noteTitle, setNoteTitle] = useState('');
+  const [noteContent, setNoteContent] = useState('');
+
+  const handleChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    if (value.length <= TITLE_MAX_LENGTH) {
+      setNoteTitle(value);
+      setTitleCount(value.length);
+    }
+  };
+
+  const handleContentChange = (text: string, content: string) => {
+    setNoteContent(content);
+    setContentWithSpaces(text.length);
+    setContentWithoutSpaces(text.replace(/\s/g, '').length);
+
+    // 아직 쓰이는 곳이 없어서 임시로 해둡니다
+    /* eslint-disable no-console */
+    console.log(noteContent);
+  };
+
   return (
-    <div>
-      <TextEditor />
+    <div className="flex h-screen items-center justify-center desktop:block">
+      <div className="mx-4 h-screen w-full max-w-[792px] desktop:ml-[360px]">
+        <div className="flex h-screen flex-col bg-white">
+          <div className="mb-4 mt-[17px] flex items-center justify-between tablet:mt-6">
+            <h1 className="text-lg font-semibold leading-7 text-slate-900">
+              노트 작성
+            </h1>
+            <div className="flex gap-2">
+              <Button
+                shape="outlined"
+                size="xs"
+                additionalClass="border-none tablet:w-[96px] tablet:h-[44px]"
+              >
+                임시 저장
+              </Button>
+              <Button
+                shape="solid"
+                size="xs"
+                additionalClass="border-none tablet:w-[96px] tablet:h-[44px]"
+              >
+                작성 완료
+              </Button>
+            </div>
+          </div>
+
+          <div className="mb-3 flex gap-[6px]">
+            <div className="flex h-6 w-6 items-center justify-center rounded-lg bg-slate-800">
+              <FlagIcon className="h-[14.4px] w-[14.4px] fill-white" />
+            </div>
+            <h3 className="font-medium leading-6 text-slate-800">
+              {MOCK_TODO.goal.title}
+            </h3>
+          </div>
+          <div className="flex items-center gap-2 border-b border-b-slate-200 pb-6">
+            <div className="flex rounded-[4px] bg-slate-100 px-[3px] py-[2px]">
+              <span className="text-xs font-medium leading-4 text-slate-700">
+                {MOCK_TODO.done ? 'Done' : 'To do'}
+              </span>
+            </div>
+            <p className="text-sm leading-5 text-slate-700">
+              {MOCK_TODO.title}
+            </p>
+          </div>
+          <div className="flex w-full items-center justify-between border-b border-b-slate-200 px-1 py-[2px]">
+            <input
+              placeholder="노트의 제목을 입력해주세요"
+              className="w-full py-3 text-lg font-medium leading-7 text-slate-800 outline-none"
+              value={noteTitle}
+              onChange={handleChangeInput}
+              maxLength={TITLE_MAX_LENGTH}
+            />
+            <div className="text-xs font-medium text-slate-800">
+              <span
+                className={`${
+                  titleCount === TITLE_MAX_LENGTH
+                    ? 'text-red-500'
+                    : 'text-blue-500'
+                }`}
+              >
+                {titleCount}
+              </span>
+              /{TITLE_MAX_LENGTH}
+            </div>
+          </div>
+          <div className="mb-2 mt-3 text-xs font-medium text-slate-800">
+            공백 포함 : 총 {contentWithSpaces}자 | 공백 제외: 총{' '}
+            {contentWithoutSpaces}자
+          </div>
+          <TextEditor onContentChange={handleContentChange} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/pages/Notes/index.tsx
+++ b/src/pages/Notes/index.tsx
@@ -4,7 +4,7 @@ import NoteList from './components/NoteList';
 function NotesPage() {
   return (
     <div className="flex items-center justify-center desktop:block">
-      <div className="w-full max-w-[792px] px-4 desktop:ml-[360px]">
+      <div className="mx-4 w-full max-w-[792px] desktop:ml-[360px]">
         <h1 className="mb-4 pt-6 text-lg font-semibold leading-7 text-slate-900">
           노트 모아보기
         </h1>


### PR DESCRIPTION
## 💻 작업 개요

<!--
ex) 구글 소셜 로그인 기능 추가
-->

- note 생성 페이지 퍼블리싱

## 💡 변경 사항 (PR 내용)

<!--
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
-->

- 배경색 때문에 App.tsx에 path 추가

## 🧐 참고 사항

<!--
리뷰 시 유의할 점, 생각해볼 문제
-->

- 전체 스크롤말고 에디터 부분만 스크롤되게 하려고 했는데 잘 안돼서 추후에 적용하겠습니다.
- 노트 상세 페이지, 노트 모아보기 페이지 css 관련도 배포 먼저 작업해보고 진행하겠습니다. 

## 🖼️ 스크린샷

<!--
스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수 있습니다. 스크린샷을 권장합니다.
![image](경로)
-->
![image](https://github.com/user-attachments/assets/25ae3229-899f-4065-ad0f-11136dd3c531)


## ️✅ 체크리스트 (PR 올리기 전 아래 내용을 확인해 주세요)

- [x] Reviewers를 지정해주세요
- [x] Assignees는 본인을 선택해주세요
- [x] label을 선택해주세요
