### PR TITLE
[Kan-31] Feature: 사이드바 API 연결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "react-router-dom": "^6.24.1",
         "react-scripts": "5.0.1",
         "tailwind-merge": "^2.4.0",
+        "tailwind-scrollbar-hide": "^1.1.7",
         "tailwindcss": "^3.4.6",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -27636,6 +27637,11 @@
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"
       }
+    },
+    "node_modules/tailwind-scrollbar-hide": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/tailwind-scrollbar-hide/-/tailwind-scrollbar-hide-1.1.7.tgz",
+      "integrity": "sha512-X324n9OtpTmOMqEgDUEA/RgLrNfBF/jwJdctaPZDzB3mppxJk7TLIDmOreEDm1Bq4R9LSPu4Epf8VSdovNU+iA=="
     },
     "node_modules/tailwindcss": {
       "version": "3.4.6",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "react-router-dom": "^6.24.1",
     "react-scripts": "5.0.1",
     "tailwind-merge": "^2.4.0",
+    "tailwind-scrollbar-hide": "^1.1.7",
     "tailwindcss": "^3.4.6",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/src/components/SideBar/DesktopSideBar.tsx
+++ b/src/components/SideBar/DesktopSideBar.tsx
@@ -5,9 +5,23 @@ interface SideBarProps {
   isOpen: boolean;
   width: number;
   toggleSideBar: () => void;
+  userData: {
+    name: string;
+    email: string;
+  };
+  goalData: {
+    title: string;
+    id: number;
+  }[];
 }
 
-function DesktopSideBar({ isOpen, width, toggleSideBar }: SideBarProps) {
+function DesktopSideBar({
+  isOpen,
+  width,
+  toggleSideBar,
+  userData,
+  goalData,
+}: SideBarProps) {
   return (
     <>
       {isOpen && width < 1920 && (
@@ -31,7 +45,9 @@ function DesktopSideBar({ isOpen, width, toggleSideBar }: SideBarProps) {
             <FoldIcon className={`${isOpen ? 'rotate-0' : 'rotate-180'}`} />
           </button>
         </div>
-        {isOpen && <DesktopSideBarContents />}
+        {isOpen && (
+          <DesktopSideBarContents userData={userData} goalData={goalData} />
+        )}
       </div>
     </>
   );

--- a/src/components/SideBar/DesktopSideBar.tsx
+++ b/src/components/SideBar/DesktopSideBar.tsx
@@ -1,4 +1,6 @@
 import { FoldIcon, LogoIcon } from '@assets';
+import TodoCreateModal from '@components/TodoModal/TodoCreateModal';
+import { useState } from 'react';
 import DesktopSideBarContents from './DesktopSideBarContents';
 
 interface SideBarProps {
@@ -22,6 +24,7 @@ function DesktopSideBar({
   userData,
   goalData,
 }: SideBarProps) {
+  const [showTodoModal, setShowTodoModal] = useState(false);
   return (
     <>
       {isOpen && width < 1920 && (
@@ -50,9 +53,13 @@ function DesktopSideBar({
             userData={userData}
             goalData={goalData}
             toggleSideBar={toggleSideBar}
+            setShowTodoModal={setShowTodoModal}
           />
         )}
       </div>
+      {showTodoModal && (
+        <TodoCreateModal onClose={() => setShowTodoModal(false)} />
+      )}
     </>
   );
 }

--- a/src/components/SideBar/DesktopSideBar.tsx
+++ b/src/components/SideBar/DesktopSideBar.tsx
@@ -31,7 +31,7 @@ function DesktopSideBar({
         />
       )}
       <div
-        className={`fixed left-0 top-0 z-50 h-dvh w-[280px] px-6 py-4 ${isOpen ? 'translate-x-0' : '-translate-x-[220px]'} border-r-[1px] bg-white transition-transform duration-300 ease-in-out`}
+        className={`fixed left-0 top-0 z-50 h-dvh w-[280px] overflow-y-scroll px-6 py-4 scrollbar-hide ${isOpen ? 'translate-x-0' : '-translate-x-[220px]'} border-r-[1px] bg-white transition-transform duration-300 ease-in-out`}
       >
         <div
           className={`fixed ${isOpen ? 'right-6' : 'right-[18px]'} top-5 h-5 w-6`}

--- a/src/components/SideBar/DesktopSideBar.tsx
+++ b/src/components/SideBar/DesktopSideBar.tsx
@@ -25,6 +25,7 @@ function DesktopSideBar({
   goalData,
 }: SideBarProps) {
   const [showTodoModal, setShowTodoModal] = useState(false);
+  const handleShowTodoModal = () => setShowTodoModal(true);
   return (
     <>
       {isOpen && width < 1920 && (
@@ -53,7 +54,7 @@ function DesktopSideBar({
             userData={userData}
             goalData={goalData}
             toggleSideBar={toggleSideBar}
-            setShowTodoModal={setShowTodoModal}
+            handleShowTodoModal={handleShowTodoModal}
           />
         )}
       </div>

--- a/src/components/SideBar/DesktopSideBar.tsx
+++ b/src/components/SideBar/DesktopSideBar.tsx
@@ -46,7 +46,11 @@ function DesktopSideBar({
           </button>
         </div>
         {isOpen && (
-          <DesktopSideBarContents userData={userData} goalData={goalData} />
+          <DesktopSideBarContents
+            userData={userData}
+            goalData={goalData}
+            toggleSideBar={toggleSideBar}
+          />
         )}
       </div>
     </>

--- a/src/components/SideBar/DesktopSideBarContents.tsx
+++ b/src/components/SideBar/DesktopSideBarContents.tsx
@@ -8,7 +8,14 @@ import {
 import Button from '@components/Button';
 import usePostGoal from '@hooks/api/goalsAPI/usePostGoal';
 import useOutsideClick from '@hooks/useOutsideClick';
-import { Dispatch, MouseEvent, SetStateAction, useRef, useState } from 'react';
+import {
+  Dispatch,
+  MouseEvent,
+  SetStateAction,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { useNavigate } from 'react-router-dom';
 
 function DesktopSideBarContents({
@@ -24,7 +31,7 @@ function DesktopSideBarContents({
 }) {
   const [isEditing, setIsEditing] = useState(false);
   const [newGoal, setNewGoal] = useState('');
-  const inputRef = useRef(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
   useOutsideClick(inputRef, () => setIsEditing(false));
 
@@ -32,6 +39,12 @@ function DesktopSideBarContents({
     e.stopPropagation();
     setIsEditing(true);
   };
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isEditing]);
 
   const { mutate, isPending } = usePostGoal();
 

--- a/src/components/SideBar/DesktopSideBarContents.tsx
+++ b/src/components/SideBar/DesktopSideBarContents.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable*/
 import {
   FlagIcon,
   HomeIcon,
@@ -10,7 +9,7 @@ import Button from '@components/Button';
 import usePostGoals from '@hooks/api/goalsAPI/usePostGoals';
 import useOutsideClick from '@hooks/useOutsideClick';
 import { useQueryClient } from '@tanstack/react-query';
-import { MouseEvent, useRef, useState } from 'react';
+import { Dispatch, MouseEvent, SetStateAction, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 function DesktopSideBarContents({
@@ -22,7 +21,7 @@ function DesktopSideBarContents({
   userData: { name: string; email: string };
   goalData: { title: string; id: number }[];
   toggleSideBar: () => void;
-  setShowTodoModal: React.Dispatch<React.SetStateAction<boolean>>;
+  setShowTodoModal: Dispatch<SetStateAction<boolean>>;
 }) {
   const [isEditing, setIsEditing] = useState(false);
   const [newGoal, setNewGoal] = useState('');
@@ -58,7 +57,14 @@ function DesktopSideBarContents({
           <div className="h-4 text-sm font-medium leading-5 text-slate-600">
             {userData.email}
           </div>
-          <button type="button">
+          <button
+            type="button"
+            onClick={() => {
+              localStorage.removeItem('accessToken');
+              localStorage.removeItem('refreshToken');
+              navigate('/sign-in');
+            }}
+          >
             <span className="text-xs font-normal leading-4 text-slate-400">
               로그아웃
             </span>

--- a/src/components/SideBar/DesktopSideBarContents.tsx
+++ b/src/components/SideBar/DesktopSideBarContents.tsx
@@ -18,17 +18,19 @@ import {
 } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+interface DesktopSideBarContentsProps {
+  userData: { name: string; email: string };
+  goalData: { title: string; id: number }[];
+  toggleSideBar: () => void;
+  setShowTodoModal: Dispatch<SetStateAction<boolean>>;
+}
+
 function DesktopSideBarContents({
   userData,
   goalData,
   toggleSideBar,
   setShowTodoModal,
-}: {
-  userData: { name: string; email: string };
-  goalData: { title: string; id: number }[];
-  toggleSideBar: () => void;
-  setShowTodoModal: Dispatch<SetStateAction<boolean>>;
-}) {
+}: DesktopSideBarContentsProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [newGoal, setNewGoal] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);

--- a/src/components/SideBar/DesktopSideBarContents.tsx
+++ b/src/components/SideBar/DesktopSideBarContents.tsx
@@ -39,7 +39,13 @@ function DesktopSideBarContents({
 
   return (
     <div className="flex-col">
-      <TextLogoIcon />
+      <TextLogoIcon
+        className="cursor-pointer"
+        onClick={() => {
+          navigate('/dashboard');
+          toggleSideBar();
+        }}
+      />
       <div className="mt-4 flex flex-row">
         <ProfileIcon width={64} height={64} />
         <div className="ml-3 flex flex-col items-start justify-between">
@@ -63,7 +69,13 @@ function DesktopSideBarContents({
         </Button>
       </div>
       <div className="absolute left-0 w-full border-b-[1px]"> </div>
-      <div className="my-4 mt-10 flex h-8 flex-row items-center">
+      <div
+        className="my-4 mt-10 flex h-8 cursor-pointer flex-row items-center"
+        onClick={() => {
+          navigate('/dashboard');
+          toggleSideBar();
+        }}
+      >
         <HomeIcon width={24} height={24} />
         <div className="ml-2 text-lg font-medium text-slate-800">대시보드</div>
       </div>

--- a/src/components/SideBar/DesktopSideBarContents.tsx
+++ b/src/components/SideBar/DesktopSideBarContents.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable*/
 import {
   FlagIcon,
   HomeIcon,
@@ -16,10 +17,12 @@ function DesktopSideBarContents({
   userData,
   goalData,
   toggleSideBar,
+  setShowTodoModal,
 }: {
   userData: { name: string; email: string };
   goalData: { title: string; id: number }[];
   toggleSideBar: () => void;
+  setShowTodoModal: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
   const [isEditing, setIsEditing] = useState(false);
   const [newGoal, setNewGoal] = useState('');
@@ -63,7 +66,14 @@ function DesktopSideBarContents({
         </div>
       </div>
       <div className="my-6 flex justify-center">
-        <Button shape="solid" size="sm" additionalClass="w-full">
+        <Button
+          shape="solid"
+          size="sm"
+          additionalClass="w-full"
+          onClick={() => {
+            setShowTodoModal(true);
+          }}
+        >
           <PlusIcon width={24} height={24} className="mr-2 stroke-white" />
           <span className="mr-2 text-base font-semibold">새 할 일</span>
         </Button>
@@ -138,7 +148,6 @@ function DesktopSideBarContents({
             height={24}
             className={`mr-2 ${isEditing ? 'stroke-slate-400' : 'stroke-blue-500'}`}
           />
-
           <span className="mr-2 text-base font-semibold">새 목표</span>
         </Button>
       </div>

--- a/src/components/SideBar/DesktopSideBarContents.tsx
+++ b/src/components/SideBar/DesktopSideBarContents.tsx
@@ -10,18 +10,22 @@ import usePostGoals from '@hooks/api/goalsAPI/usePostGoals';
 import useOutsideClick from '@hooks/useOutsideClick';
 import { useQueryClient } from '@tanstack/react-query';
 import { MouseEvent, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 function DesktopSideBarContents({
   userData,
   goalData,
+  toggleSideBar,
 }: {
   userData: { name: string; email: string };
   goalData: { title: string; id: number }[];
+  toggleSideBar: () => void;
 }) {
   const [isEditing, setIsEditing] = useState(false);
   const [newGoal, setNewGoal] = useState('');
   const inputRef = useRef(null);
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   useOutsideClick(inputRef, () => setIsEditing(false));
 
   const handleAddGoalBtn = (e: MouseEvent) => {
@@ -70,9 +74,19 @@ function DesktopSideBarContents({
       </div>
       <ul>
         {goalData.map((item) => (
-          <li key={item.id} className="p-2 text-sm font-medium text-slate-700">
-            • {item.title}
-          </li>
+          <div
+            onClick={() => {
+              navigate('/goal-detail');
+              toggleSideBar();
+            }}
+          >
+            <li
+              key={item.id}
+              className="cursor-pointer p-2 text-sm font-medium text-slate-700"
+            >
+              • {item.title}
+            </li>
+          </div>
         ))}
         {isPending && (
           <li className="p-2 text-sm font-medium text-slate-700">

--- a/src/components/SideBar/DesktopSideBarContents.tsx
+++ b/src/components/SideBar/DesktopSideBarContents.tsx
@@ -8,7 +8,6 @@ import {
 import Button from '@components/Button';
 import usePostGoal from '@hooks/api/goalsAPI/usePostGoal';
 import useOutsideClick from '@hooks/useOutsideClick';
-import { useQueryClient } from '@tanstack/react-query';
 import { Dispatch, MouseEvent, SetStateAction, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -26,7 +25,6 @@ function DesktopSideBarContents({
   const [isEditing, setIsEditing] = useState(false);
   const [newGoal, setNewGoal] = useState('');
   const inputRef = useRef(null);
-  const queryClient = useQueryClient();
   const navigate = useNavigate();
   useOutsideClick(inputRef, () => setIsEditing(false));
 
@@ -34,10 +32,8 @@ function DesktopSideBarContents({
     e.stopPropagation();
     setIsEditing(true);
   };
-  const onSettled = () =>
-    queryClient.invalidateQueries({ queryKey: ['goals'] });
 
-  const { mutate, isPending } = usePostGoal(onSettled);
+  const { mutate, isPending } = usePostGoal();
 
   return (
     <div className="flex-col">

--- a/src/components/SideBar/DesktopSideBarContents.tsx
+++ b/src/components/SideBar/DesktopSideBarContents.tsx
@@ -8,28 +8,21 @@ import {
 import Button from '@components/Button';
 import usePostGoal from '@hooks/api/goalsAPI/usePostGoal';
 import useOutsideClick from '@hooks/useOutsideClick';
-import {
-  Dispatch,
-  MouseEvent,
-  SetStateAction,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import { MouseEvent, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 interface DesktopSideBarContentsProps {
   userData: { name: string; email: string };
   goalData: { title: string; id: number }[];
   toggleSideBar: () => void;
-  setShowTodoModal: Dispatch<SetStateAction<boolean>>;
+  handleShowTodoModal: () => void;
 }
 
 function DesktopSideBarContents({
   userData,
   goalData,
   toggleSideBar,
-  setShowTodoModal,
+  handleShowTodoModal,
 }: DesktopSideBarContentsProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [newGoal, setNewGoal] = useState('');
@@ -87,9 +80,7 @@ function DesktopSideBarContents({
           shape="solid"
           size="sm"
           additionalClass="w-full"
-          onClick={() => {
-            setShowTodoModal(true);
-          }}
+          onClick={handleShowTodoModal}
         >
           <PlusIcon width={24} height={24} className="mr-2 stroke-white" />
           <span className="mr-2 text-base font-semibold">새 할 일</span>

--- a/src/components/SideBar/DesktopSideBarContents.tsx
+++ b/src/components/SideBar/DesktopSideBarContents.tsx
@@ -6,7 +6,7 @@ import {
   TextLogoIcon,
 } from '@assets';
 import Button from '@components/Button';
-import usePostGoals from '@hooks/api/goalsAPI/usePostGoals';
+import usePostGoal from '@hooks/api/goalsAPI/usePostGoal';
 import useOutsideClick from '@hooks/useOutsideClick';
 import { useQueryClient } from '@tanstack/react-query';
 import { Dispatch, MouseEvent, SetStateAction, useRef, useState } from 'react';
@@ -37,7 +37,7 @@ function DesktopSideBarContents({
   const onSettled = () =>
     queryClient.invalidateQueries({ queryKey: ['goals'] });
 
-  const { mutate, isPending } = usePostGoals(onSettled);
+  const { mutate, isPending } = usePostGoal(onSettled);
 
   return (
     <div className="flex-col">

--- a/src/components/SideBar/MobileSideBar.tsx
+++ b/src/components/SideBar/MobileSideBar.tsx
@@ -4,9 +4,16 @@ import MobileSideBarContents from './MobileSideBarContents';
 interface MobileSideBarProps {
   isOpen: boolean;
   toggleSideBar: () => void;
+  userData: { name: string; email: string };
+  goalData: { title: string; id: number }[];
 }
 
-function MobileSideBar({ isOpen, toggleSideBar }: MobileSideBarProps) {
+function MobileSideBar({
+  isOpen,
+  toggleSideBar,
+  userData,
+  goalData,
+}: MobileSideBarProps) {
   return (
     <>
       <div className="h-12 w-full bg-white">
@@ -30,7 +37,9 @@ function MobileSideBar({ isOpen, toggleSideBar }: MobileSideBarProps) {
         >
           <FoldIcon />
         </button>
-        {isOpen && <MobileSideBarContents />}
+        {isOpen && (
+          <MobileSideBarContents userData={userData} goalData={goalData} />
+        )}
       </div>
     </>
   );

--- a/src/components/SideBar/MobileSideBar.tsx
+++ b/src/components/SideBar/MobileSideBar.tsx
@@ -27,7 +27,9 @@ function MobileSideBar({
         </button>
       </div>
       <div
-        className={`fixed left-0 top-0 z-50 h-dvh w-full px-6 py-4 ${isOpen ? 'translate-x-0' : '-translate-x-full'} bg-white transition-transform duration-300 ease-in-out`}
+        // 프리티어 설정이랑 린트 설정이랑 안맞는지 scrollbar-hide 위치때문에 린트 에러가 나서 주석처리 했습니다.
+        // eslint-disable-next-line
+        className={`fixed left-0 top-0 z-50 h-dvh w-full overflow-y-scroll px-6 py-4 scrollbar-hide ${isOpen ? 'translate-x-0' : '-translate-x-full'} bg-white transition-transform duration-300 ease-in-out`}
       >
         <button
           type="button"

--- a/src/components/SideBar/MobileSideBar.tsx
+++ b/src/components/SideBar/MobileSideBar.tsx
@@ -1,4 +1,6 @@
 import { FoldIcon, HamburgerIcon } from '@assets';
+import TodoCreateModal from '@components/TodoModal/TodoCreateModal';
+import { useState } from 'react';
 import MobileSideBarContents from './MobileSideBarContents';
 
 interface MobileSideBarProps {
@@ -14,6 +16,9 @@ function MobileSideBar({
   userData,
   goalData,
 }: MobileSideBarProps) {
+  const [showTodoModal, setShowTodoModal] = useState(false);
+  const handleShowTodoModal = () => setShowTodoModal(true);
+
   return (
     <>
       <div className="h-12 w-full bg-white">
@@ -44,9 +49,18 @@ function MobileSideBar({
             userData={userData}
             goalData={goalData}
             toggleSideBar={toggleSideBar}
+            handleShowTodoModal={handleShowTodoModal}
           />
         )}
       </div>
+      {showTodoModal && (
+        <TodoCreateModal
+          onClose={() => {
+            setShowTodoModal(false);
+            toggleSideBar();
+          }}
+        />
+      )}
     </>
   );
 }

--- a/src/components/SideBar/MobileSideBar.tsx
+++ b/src/components/SideBar/MobileSideBar.tsx
@@ -40,7 +40,11 @@ function MobileSideBar({
           <FoldIcon />
         </button>
         {isOpen && (
-          <MobileSideBarContents userData={userData} goalData={goalData} />
+          <MobileSideBarContents
+            userData={userData}
+            goalData={goalData}
+            toggleSideBar={toggleSideBar}
+          />
         )}
       </div>
     </>

--- a/src/components/SideBar/MobileSideBarContents.tsx
+++ b/src/components/SideBar/MobileSideBarContents.tsx
@@ -41,7 +41,13 @@ function MobileSideBarContents({
 
   return (
     <div className="flex-col">
-      <TextLogoIcon />
+      <TextLogoIcon
+        className="cursor-pointer"
+        onClick={() => {
+          navigate('/dashboard');
+          toggleSideBar();
+        }}
+      />
       <div className="mb-6 mt-4 flex flex-row justify-between">
         <div className="flex flex-row">
           <ProfileIcon width={32} height={32} />
@@ -66,7 +72,13 @@ function MobileSideBarContents({
       <div className="absolute left-0 w-full border-b-[1px]" />
 
       <div className="my-3 mt-9 flex h-8 flex-row items-center justify-between">
-        <div className="flex flex-row">
+        <div
+          className="flex cursor-pointer flex-row"
+          onClick={() => {
+            navigate('/dashboard');
+            toggleSideBar();
+          }}
+        >
           <HomeIcon width={24} height={24} />
           <div className="ml-2 text-lg font-medium text-slate-800">
             대시보드

--- a/src/components/SideBar/MobileSideBarContents.tsx
+++ b/src/components/SideBar/MobileSideBarContents.tsx
@@ -7,7 +7,7 @@ import {
 } from '@assets';
 import Button from '@components/Button';
 import TodoCreateModal from '@components/TodoModal/TodoCreateModal';
-import usePostGoals from '@hooks/api/goalsAPI/usePostGoals';
+import usePostGoal from '@hooks/api/goalsAPI/usePostGoal';
 import useOutsideClick from '@hooks/useOutsideClick';
 import { useQueryClient } from '@tanstack/react-query';
 import { MouseEvent, useEffect, useRef, useState } from 'react';
@@ -44,7 +44,7 @@ function MobileSideBarContents({
   const onSettled = () =>
     queryClient.invalidateQueries({ queryKey: ['goals'] });
 
-  const { mutate, isPending } = usePostGoals(onSettled);
+  const { mutate, isPending } = usePostGoal(onSettled);
 
   const [showTodoModal, setShowTodoModal] = useState(false);
 

--- a/src/components/SideBar/MobileSideBarContents.tsx
+++ b/src/components/SideBar/MobileSideBarContents.tsx
@@ -10,7 +10,7 @@ import TodoCreateModal from '@components/TodoModal/TodoCreateModal';
 import usePostGoals from '@hooks/api/goalsAPI/usePostGoals';
 import useOutsideClick from '@hooks/useOutsideClick';
 import { useQueryClient } from '@tanstack/react-query';
-import { MouseEvent, useRef, useState } from 'react';
+import { MouseEvent, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 function MobileSideBarContents({
@@ -24,7 +24,7 @@ function MobileSideBarContents({
 }) {
   const [isEditing, setIsEditing] = useState(false);
   const [newGoal, setNewGoal] = useState('');
-  const inputRef = useRef(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
@@ -34,6 +34,12 @@ function MobileSideBarContents({
     e.stopPropagation();
     setIsEditing(true);
   };
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isEditing]);
 
   const onSettled = () =>
     queryClient.invalidateQueries({ queryKey: ['goals'] });
@@ -161,6 +167,7 @@ function MobileSideBarContents({
                 if (event.key === 'Enter') {
                   setIsEditing(false);
                   mutate(newGoal);
+                  setNewGoal('');
                 }
               }}
             />

--- a/src/components/SideBar/MobileSideBarContents.tsx
+++ b/src/components/SideBar/MobileSideBarContents.tsx
@@ -6,7 +6,6 @@ import {
   TextLogoIcon,
 } from '@assets';
 import Button from '@components/Button';
-import TodoCreateModal from '@components/TodoModal/TodoCreateModal';
 import usePostGoal from '@hooks/api/goalsAPI/usePostGoal';
 import useOutsideClick from '@hooks/useOutsideClick';
 import { MouseEvent, useEffect, useRef, useState } from 'react';
@@ -16,12 +15,14 @@ interface MobileSideBarContentsProps {
   userData: { name: string; email: string };
   goalData: { title: string; id: number }[];
   toggleSideBar: () => void;
+  handleShowTodoModal: () => void;
 }
 
 function MobileSideBarContents({
   userData,
   goalData,
   toggleSideBar,
+  handleShowTodoModal,
 }: MobileSideBarContentsProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [newGoal, setNewGoal] = useState('');
@@ -42,8 +43,6 @@ function MobileSideBarContents({
   }, [isEditing]);
 
   const { mutate, isPending } = usePostGoal();
-
-  const [showTodoModal, setShowTodoModal] = useState(false);
 
   return (
     <div className="flex-col">
@@ -97,13 +96,7 @@ function MobileSideBarContents({
             대시보드
           </div>
         </div>
-        <Button
-          shape="solid"
-          size="xs"
-          onClick={() => {
-            setShowTodoModal(true);
-          }}
-        >
+        <Button shape="solid" size="xs" onClick={handleShowTodoModal}>
           <PlusIcon width={16} height={16} className="stroke-white" />
           <span className="ml-0.5 text-sm font-semibold">새 할 일</span>
         </Button>
@@ -171,14 +164,6 @@ function MobileSideBarContents({
           </li>
         )}
       </ul>
-      {showTodoModal && (
-        <TodoCreateModal
-          onClose={() => {
-            setShowTodoModal(false);
-            toggleSideBar();
-          }}
-        />
-      )}
     </div>
   );
 }

--- a/src/components/SideBar/MobileSideBarContents.tsx
+++ b/src/components/SideBar/MobileSideBarContents.tsx
@@ -10,17 +10,21 @@ import usePostGoals from '@hooks/api/goalsAPI/usePostGoals';
 import useOutsideClick from '@hooks/useOutsideClick';
 import { useQueryClient } from '@tanstack/react-query';
 import { MouseEvent, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 function MobileSideBarContents({
   userData,
   goalData,
+  toggleSideBar,
 }: {
   userData: { name: string; email: string };
   goalData: { title: string; id: number }[];
+  toggleSideBar: () => void;
 }) {
   const [isEditing, setIsEditing] = useState(false);
   const [newGoal, setNewGoal] = useState('');
   const inputRef = useRef(null);
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
 
   useOutsideClick(inputRef, () => setIsEditing(false));
@@ -97,9 +101,19 @@ function MobileSideBarContents({
       </div>
       <ul>
         {goalData.map((item) => (
-          <li key={item.id} className="p-2 text-sm font-medium text-slate-700">
-            • {item.title}
-          </li>
+          <div
+            onClick={() => {
+              navigate('/goal-detail');
+              toggleSideBar();
+            }}
+          >
+            <li
+              key={item.id}
+              className="cursor-pointer p-2 text-sm font-medium text-slate-700"
+            >
+              • {item.title}
+            </li>
+          </div>
         ))}
         {isPending && (
           <li className="p-2 text-sm font-medium text-slate-700">

--- a/src/components/SideBar/MobileSideBarContents.tsx
+++ b/src/components/SideBar/MobileSideBarContents.tsx
@@ -9,7 +9,6 @@ import Button from '@components/Button';
 import TodoCreateModal from '@components/TodoModal/TodoCreateModal';
 import usePostGoal from '@hooks/api/goalsAPI/usePostGoal';
 import useOutsideClick from '@hooks/useOutsideClick';
-import { useQueryClient } from '@tanstack/react-query';
 import { MouseEvent, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -26,7 +25,6 @@ function MobileSideBarContents({
   const [newGoal, setNewGoal] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
 
   useOutsideClick(inputRef, () => setIsEditing(false));
 
@@ -41,10 +39,7 @@ function MobileSideBarContents({
     }
   }, [isEditing]);
 
-  const onSettled = () =>
-    queryClient.invalidateQueries({ queryKey: ['goals'] });
-
-  const { mutate, isPending } = usePostGoal(onSettled);
+  const { mutate, isPending } = usePostGoal();
 
   const [showTodoModal, setShowTodoModal] = useState(false);
 

--- a/src/components/SideBar/MobileSideBarContents.tsx
+++ b/src/components/SideBar/MobileSideBarContents.tsx
@@ -12,15 +12,17 @@ import useOutsideClick from '@hooks/useOutsideClick';
 import { MouseEvent, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+interface MobileSideBarContentsProps {
+  userData: { name: string; email: string };
+  goalData: { title: string; id: number }[];
+  toggleSideBar: () => void;
+}
+
 function MobileSideBarContents({
   userData,
   goalData,
   toggleSideBar,
-}: {
-  userData: { name: string; email: string };
-  goalData: { title: string; id: number }[];
-  toggleSideBar: () => void;
-}) {
+}: MobileSideBarContentsProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [newGoal, setNewGoal] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);

--- a/src/components/SideBar/MobileSideBarContents.tsx
+++ b/src/components/SideBar/MobileSideBarContents.tsx
@@ -64,7 +64,14 @@ function MobileSideBarContents({
           </div>
         </div>
         <div className="flex items-end">
-          <button type="button">
+          <button
+            type="button"
+            onClick={() => {
+              localStorage.removeItem('accessToken');
+              localStorage.removeItem('refreshToken');
+              navigate('/sign-in');
+            }}
+          >
             <span className="text-xs font-normal leading-4 text-slate-400">
               로그아웃
             </span>

--- a/src/components/SideBar/MobileSideBarContents.tsx
+++ b/src/components/SideBar/MobileSideBarContents.tsx
@@ -6,24 +6,34 @@ import {
   TextLogoIcon,
 } from '@assets';
 import Button from '@components/Button';
+import usePostGoals from '@hooks/api/goalsAPI/usePostGoals';
 import useOutsideClick from '@hooks/useOutsideClick';
+import { useQueryClient } from '@tanstack/react-query';
 import { MouseEvent, useRef, useState } from 'react';
 
-function MobileSideBarContents() {
+function MobileSideBarContents({
+  userData,
+  goalData,
+}: {
+  userData: { name: string; email: string };
+  goalData: { title: string; id: number }[];
+}) {
   const [isEditing, setIsEditing] = useState(false);
+  const [newGoal, setNewGoal] = useState('');
   const inputRef = useRef(null);
-  const mockGoalData = {
-    goals: [
-      { title: '자바스크립트로 웹 서비스 만들기', id: 1 },
-      { title: '디자인 시스템 강의 듣기', id: 2 },
-    ],
-  };
+  const queryClient = useQueryClient();
+
   useOutsideClick(inputRef, () => setIsEditing(false));
 
   const handleAddGoalBtn = (e: MouseEvent) => {
     e.stopPropagation();
     setIsEditing(true);
   };
+
+  const onSettled = () =>
+    queryClient.invalidateQueries({ queryKey: ['goals'] });
+
+  const { mutate, isPending } = usePostGoals(onSettled);
 
   return (
     <div className="flex-col">
@@ -33,10 +43,10 @@ function MobileSideBarContents() {
           <ProfileIcon width={32} height={32} />
           <div className="ml-3 flex flex-col items-start justify-between">
             <div className="h-4 text-xs font-semibold leading-5 text-slate-800">
-              체다치즈
+              {userData.name}
             </div>
             <div className="h-4 text-xs font-medium leading-5 text-slate-600">
-              chedacheese@slid.kr
+              {userData.email}
             </div>
           </div>
         </div>
@@ -86,11 +96,16 @@ function MobileSideBarContents() {
         </Button>
       </div>
       <ul>
-        {mockGoalData.goals.map((item) => (
+        {goalData.map((item) => (
           <li key={item.id} className="p-2 text-sm font-medium text-slate-700">
             • {item.title}
           </li>
         ))}
+        {isPending && (
+          <li className="p-2 text-sm font-medium text-slate-700">
+            • {newGoal}
+          </li>
+        )}
         {isEditing && (
           <li className="flex items-center p-2 text-sm font-medium text-slate-700">
             <span>•</span>
@@ -98,10 +113,12 @@ function MobileSideBarContents() {
               ref={inputRef}
               className="ml-1 h-8 w-max flex-grow rounded-md border border-gray-300 p-2 text-sm"
               placeholder="새 목표를 입력해주세요"
+              value={newGoal}
+              onChange={(e) => setNewGoal(e.target.value)}
               onKeyDown={(event) => {
-                // TODO: 엔터키 입력 시 목표 추가
                 if (event.key === 'Enter') {
                   setIsEditing(false);
+                  mutate(newGoal);
                 }
               }}
             />

--- a/src/components/SideBar/MobileSideBarContents.tsx
+++ b/src/components/SideBar/MobileSideBarContents.tsx
@@ -6,6 +6,7 @@ import {
   TextLogoIcon,
 } from '@assets';
 import Button from '@components/Button';
+import TodoCreateModal from '@components/TodoModal/TodoCreateModal';
 import usePostGoals from '@hooks/api/goalsAPI/usePostGoals';
 import useOutsideClick from '@hooks/useOutsideClick';
 import { useQueryClient } from '@tanstack/react-query';
@@ -38,6 +39,8 @@ function MobileSideBarContents({
     queryClient.invalidateQueries({ queryKey: ['goals'] });
 
   const { mutate, isPending } = usePostGoals(onSettled);
+
+  const [showTodoModal, setShowTodoModal] = useState(false);
 
   return (
     <div className="flex-col">
@@ -84,7 +87,13 @@ function MobileSideBarContents({
             대시보드
           </div>
         </div>
-        <Button shape="solid" size="xs">
+        <Button
+          shape="solid"
+          size="xs"
+          onClick={() => {
+            setShowTodoModal(true);
+          }}
+        >
           <PlusIcon width={16} height={16} className="stroke-white" />
           <span className="ml-0.5 text-sm font-semibold">새 할 일</span>
         </Button>
@@ -151,6 +160,14 @@ function MobileSideBarContents({
           </li>
         )}
       </ul>
+      {showTodoModal && (
+        <TodoCreateModal
+          onClose={() => {
+            setShowTodoModal(false);
+            toggleSideBar();
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -21,10 +21,6 @@ function SideBar() {
   const { data: userData } = useGetUser();
   const { data: goalData } = useGetGoals();
 
-  useEffect(() => {
-    console.log(goalData?.pages[0].data.goals);
-  }, [goalData]);
-
   if (!userData || !goalData) return null;
 
   return (

--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -21,6 +21,14 @@ function SideBar() {
   const { data: userData } = useGetUser();
   const { data: goalData } = useGetGoals();
 
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+  }, [isOpen]);
+
   if (!userData || !goalData) return null;
 
   return (

--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -1,3 +1,5 @@
+import useGetGoals from '@hooks/api/goalsAPI/useGetGoals';
+import useGetUser from '@hooks/api/userAPI/useGetUser';
 import useWindowWidth from '@hooks/useWindowWidth';
 import { useEffect, useState } from 'react';
 import DesktopSideBar from './DesktopSideBar';
@@ -16,6 +18,15 @@ function SideBar() {
     }
   }, [width]);
 
+  const { data: userData } = useGetUser();
+  const { data: goalData } = useGetGoals();
+
+  useEffect(() => {
+    console.log(goalData?.pages[0].data.goals);
+  }, [goalData]);
+
+  if (!userData || !goalData) return null;
+
   return (
     <>
       {width >= 744 ? (
@@ -23,9 +34,16 @@ function SideBar() {
           toggleSideBar={toggleSidebar}
           isOpen={isOpen}
           width={width}
+          userData={userData.data}
+          goalData={goalData.pages[0].data.goals}
         />
       ) : (
-        <MobileSideBar toggleSideBar={toggleSidebar} isOpen={isOpen} />
+        <MobileSideBar
+          toggleSideBar={toggleSidebar}
+          isOpen={isOpen}
+          userData={userData.data}
+          goalData={goalData.pages[0].data.goals}
+        />
       )}
     </>
   );

--- a/src/hooks/api/goalsAPI/usePostGoal.ts
+++ b/src/hooks/api/goalsAPI/usePostGoal.ts
@@ -1,10 +1,12 @@
 import goalsAPI from '@app/api/goalsAPI';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-const usePostGoal = (onSettled: () => void) =>
-  useMutation({
+const usePostGoal = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
     mutationFn: (newGoal: string) => goalsAPI.postGoal(newGoal),
-    onSettled: () => onSettled(),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ['goals'] }),
   });
+};
 
 export default usePostGoal;

--- a/src/hooks/api/goalsAPI/usePostGoal.ts
+++ b/src/hooks/api/goalsAPI/usePostGoal.ts
@@ -1,10 +1,10 @@
 import goalsAPI from '@app/api/goalsAPI';
 import { useMutation } from '@tanstack/react-query';
 
-const usePostGoals = (onSettled: () => void) =>
+const usePostGoal = (onSettled: () => void) =>
   useMutation({
     mutationFn: (newGoal: string) => goalsAPI.postGoal(newGoal),
     onSettled: () => onSettled(),
   });
 
-export default usePostGoals;
+export default usePostGoal;

--- a/src/hooks/api/goalsAPI/usePostGoals.ts
+++ b/src/hooks/api/goalsAPI/usePostGoals.ts
@@ -1,0 +1,10 @@
+import goalsAPI from '@app/api/goalsAPI';
+import { useMutation } from '@tanstack/react-query';
+
+const usePostGoals = (onSettled: () => void) =>
+  useMutation({
+    mutationFn: (newGoal: string) => goalsAPI.postGoal(newGoal),
+    onSettled: () => onSettled(),
+  });
+
+export default usePostGoals;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -28,5 +28,5 @@ module.exports = {
       desktop: '1920px',
     },
   },
-  plugins: [],
+  plugins: [require('tailwind-scrollbar-hide')],
 };


### PR DESCRIPTION
## 💻 작업 개요

<!--
ex) 구글 소셜 로그인 기능 추가
-->

- 사이드바 API 연결

## 💡 변경 사항 (PR 내용)

<!--
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
-->

- 사이드바 API 연결 -> 목표 추가 낙관적 업데이트 구현
- 목표가 많아지면 사이드바 내부 스크롤
- 사이드바가 켜지면 사이드바 외부 스크롤 방지 -> 모바일에서 스크롤 내려갔을 때 주소창이 사라지면서 생기던 UI 문제 해결
- 목표 추가 클릭 시 자동 포커싱
- 할일 추가 버튼 클릭 시 할일 추가 모달 띄우기
- 로그아웃 버튼 구현
- 그 외 각종 버튼 클릭 이벤트 구현

## 🧐 참고 사항

<!--
리뷰 시 유의할 점, 생각해볼 문제
-->

- 현재 모바일이랑 데스크톱이 겹치는 코드가 너무 많아서 이걸 리팩토링 하면 좋을 것 같습니다. 만들면서 왔다갔다 너무 헷갈렸어요 ㅋㅋ ㅠ

## 🖼️ 스크린샷

<!--
스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수 있습니다. 스크린샷을 권장합니다.
![image](경로)
-->

## ️✅ 체크리스트 (PR 올리기 전 아래 내용을 확인해 주세요)

- [x] Reviewers를 지정해주세요
- [x] Assignees는 본인을 선택해주세요
- [x] label을 선택해주세요
