### PR TITLE
[Kan-81] Feature: 노트 목록, 상세 API 연결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,8 +31,8 @@ function App() {
     pathname === '/sign-in' ||
     pathname === '/sign-up' ||
     pathname === '/notes/new'
-      ? 'bg-white'
-      : 'bg-slate-200';
+      ? '#fff'
+      : '#E2E8F0';
 
   const navigate = useNavigate();
 
@@ -42,11 +42,13 @@ function App() {
     }
   }, []);
 
+  useEffect(() => {
+    document.body.style.backgroundColor = bgColor;
+  }, [bgColor]);
+
   return (
     <QueryClientProvider client={queryClient}>
-      <div
-        className={`h-dvh w-dvw ${bgColor} font-Pretendard text-base font-normal`}
-      >
+      <div className="h-dvh w-dvw font-Pretendard text-base font-normal">
         {pathname !== '/sign-in' && pathname !== '/sign-up' && <SideBar />}
         <div className="ml-0 tablet:ml-[60px] desktop:ml-0">
           <Outlet />

--- a/src/components/Kebab/index.tsx
+++ b/src/components/Kebab/index.tsx
@@ -19,12 +19,14 @@ function Kebab({ onEdit, onDelete, isSmall = false }: KebabProps) {
 
   useOutsideClick(popOverRef, () => setIsPopOverOpen(false));
 
-  const handleEditClick = () => {
+  const handleEditClick = (e: MouseEvent) => {
+    e.stopPropagation();
     onEdit();
     setIsPopOverOpen(false);
   };
 
-  const handleDeleteClick = () => {
+  const handleDeleteClick = (e: MouseEvent) => {
+    e.stopPropagation();
     onDelete();
     setIsPopOverOpen(false);
   };

--- a/src/components/NoteDetail/index.tsx
+++ b/src/components/NoteDetail/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { DeleteIcon, FlagIcon, GrayDelete } from '@assets';
 import Kebab from '@components/Kebab';
 import useDeleteNote from '@hooks/api/notesAPI/useDeleteNote';
@@ -19,8 +18,11 @@ function NoteDetail({ onClose, noteId }: NoteDetailProps) {
   const { mutate } = useDeleteNote();
 
   useEffect(() => {
-    setIsOpen(true);
-  }, []);
+    if (noteData) {
+      // 애니메이션 효과를 위해 일정 시간 후에 isOpen을 true로 변경 (안그러면 애니메이션이 제대로 적용이 안됨)
+      setTimeout(() => setIsOpen(true), 10);
+    }
+  }, [noteData]);
 
   const handleClose = () => {
     setIsOpen(false);

--- a/src/components/NoteDetail/index.tsx
+++ b/src/components/NoteDetail/index.tsx
@@ -39,7 +39,7 @@ function NoteDetail({ onClose, noteId }: NoteDetailProps) {
     <>
       {isOpen && (
         <div
-          className="absolute left-0 top-0 z-20 h-dvh w-dvw opacity-50 tablet:bg-black"
+          className="fixed left-0 top-0 z-20 h-dvh w-dvw opacity-50 tablet:bg-black"
           onClick={handleClose}
         />
       )}

--- a/src/components/NoteDetail/index.tsx
+++ b/src/components/NoteDetail/index.tsx
@@ -1,38 +1,22 @@
+/* eslint-disable */
 import { DeleteIcon, FlagIcon, GrayDelete } from '@assets';
 import Kebab from '@components/Kebab';
+import useDeleteNote from '@hooks/api/notesAPI/useDeleteNote';
+import useGetNote from '@hooks/api/notesAPI/useGetNote';
 import formatDate from '@utils/formatDate';
 
 import { useEffect, useState } from 'react';
 
-const MOCK_NOTE_DETAIL = {
-  todo: {
-    done: true,
-    fileUrl: 'string',
-    linkUrl: 'string',
-    title: '자바스크립트 기초 챕터 1 듣기',
-    id: 0,
-  },
-  linkUrl: 'https://',
-  content:
-    '자바는 어떤 배경에서 처음 만들어 졌는지, 또한 시대의 흐름에 따라 어떻게 변화해 왔는지, 어떤 요구사항들로 인해 새로운 기술들이 개발되었는지 살펴보는 것은 자바를 보다 잘 이해하는데 도움이 됩니다.',
-  updatedAt: '2024-07-30T08:19:41.533Z',
-  createdAt: '2024-07-29T08:19:41.533Z',
-  title: '프로그래밍과 데이터 in JavaScript',
-  id: 1,
-  goal: {
-    title: '자바스크립트로 웹 서비스 만들기',
-    id: 0,
-  },
-  userId: 0,
-  teamId: 'string',
-};
-
 interface NoteDetailProps {
   onClose: () => void;
+  noteId: number;
 }
 
-function NoteDetail({ onClose }: NoteDetailProps) {
+function NoteDetail({ onClose, noteId }: NoteDetailProps) {
   const [isOpen, setIsOpen] = useState(false);
+
+  const { data: noteData } = useGetNote(noteId);
+  const { mutate } = useDeleteNote();
 
   useEffect(() => {
     setIsOpen(true);
@@ -44,11 +28,11 @@ function NoteDetail({ onClose }: NoteDetailProps) {
   };
 
   const handleEditNote = () => {
-    //
+    // 노트 수정 페이지로 이동
   };
 
   const handleDeleteNote = () => {
-    //
+    mutate(noteId);
   };
 
   return (
@@ -59,64 +43,66 @@ function NoteDetail({ onClose }: NoteDetailProps) {
           onClick={handleClose}
         />
       )}
-      <div
-        className={`fixed right-0 top-0 z-30 h-screen bg-white p-6 shadow-lg transition-all duration-300 ease-in-out ${isOpen ? 'translate-x-0' : 'translate-x-full'} tablet:w-[512px] desktop:w-[800px]`}
-      >
-        <DeleteIcon className="mb-4 cursor-pointer" onClick={handleClose} />
-        <div className="flex flex-col gap-3 border-b-[1px] border-slate-200 pb-6">
-          <div className="flex items-center justify-between">
-            <div className="flex gap-[6px]">
-              <div className="flex h-6 w-6 items-center justify-center rounded-lg bg-slate-800">
-                <FlagIcon className="h-[14.4px] w-[14.4px] fill-white" />
+      {noteData && (
+        <div
+          className={`fixed right-0 top-0 z-30 h-screen bg-white p-6 shadow-lg transition-all duration-300 ease-in-out ${isOpen ? 'translate-x-0' : 'translate-x-full'} tablet:w-[512px] desktop:w-[800px]`}
+        >
+          <DeleteIcon className="mb-4 cursor-pointer" onClick={handleClose} />
+          <div className="flex flex-col gap-3 border-b-[1px] border-slate-200 pb-6">
+            <div className="flex items-center justify-between">
+              <div className="flex gap-[6px]">
+                <div className="flex h-6 w-6 items-center justify-center rounded-lg bg-slate-800">
+                  <FlagIcon className="h-[14.4px] w-[14.4px] fill-white" />
+                </div>
+                <h3 className="font-medium leading-6 text-slate-800">
+                  {noteData.data.goal.title}
+                </h3>
               </div>
-              <h3 className="font-medium leading-6 text-slate-800">
-                {MOCK_NOTE_DETAIL.goal.title}
-              </h3>
+              <Kebab
+                onEdit={handleEditNote}
+                onDelete={handleDeleteNote}
+                isSmall
+              />
             </div>
-            <Kebab
-              onEdit={handleEditNote}
-              onDelete={handleDeleteNote}
-              isSmall
-            />
-          </div>
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <div className="flex rounded-[4px] bg-slate-100 px-[3px] py-[2px]">
-                <span className="text-xs font-medium leading-4 text-slate-700">
-                  {MOCK_NOTE_DETAIL.todo.done ? 'Done' : 'To do'}
-                </span>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <div className="flex rounded-[4px] bg-slate-100 px-[3px] py-[2px]">
+                  <span className="text-xs font-medium leading-4 text-slate-700">
+                    {noteData.data.todo.done ? 'Done' : 'To do'}
+                  </span>
+                </div>
+                <p className="text-sm leading-5 text-slate-700">
+                  {noteData.data.todo.title}
+                </p>
               </div>
-              <p className="text-sm leading-5 text-slate-700">
-                {MOCK_NOTE_DETAIL.todo.title}
+              <p className="text-xs leading-4 text-slate-500">
+                {formatDate(noteData.data.createdAt)} 작성
+                {noteData.data.createdAt !== noteData.data.updatedAt
+                  ? ` | ${formatDate(noteData.data.updatedAt)} 수정`
+                  : ''}
               </p>
             </div>
-            <p className="text-xs leading-4 text-slate-500">
-              {formatDate(MOCK_NOTE_DETAIL.createdAt)} 작성
-              {MOCK_NOTE_DETAIL.createdAt !== MOCK_NOTE_DETAIL.updatedAt
-                ? ` | ${formatDate(MOCK_NOTE_DETAIL.updatedAt)} 수정`
-                : ''}
-            </p>
+          </div>
+          <div className="border-b-[1px] border-slate-200 py-3">
+            <h2 className="text-lg font-medium leading-7 text-slate-800">
+              {noteData.data.title}
+            </h2>
+          </div>
+          <div
+            className={`leading-6 text-slate-700 ${noteData.data.linkUrl ? 'pt-3' : 'pt-4'}`}
+          >
+            {noteData.data.linkUrl ? (
+              <div className="mb-4 flex justify-between rounded-[20px] bg-slate-200 py-1 pl-4 pr-[6px]">
+                {noteData.data.linkUrl}
+                <GrayDelete className="cursor-pointer" />
+              </div>
+            ) : (
+              <div className="pt-1" />
+            )}
+            {noteData.data.content}
           </div>
         </div>
-        <div className="border-b-[1px] border-slate-200 py-3">
-          <h2 className="text-lg font-medium leading-7 text-slate-800">
-            {MOCK_NOTE_DETAIL.title}
-          </h2>
-        </div>
-        <div
-          className={`leading-6 text-slate-700 ${MOCK_NOTE_DETAIL.linkUrl ? 'pt-3' : 'pt-4'}`}
-        >
-          {MOCK_NOTE_DETAIL.linkUrl ? (
-            <div className="mb-4 flex justify-between rounded-[20px] bg-slate-200 py-1 pl-4 pr-[6px]">
-              {MOCK_NOTE_DETAIL.linkUrl}
-              <GrayDelete className="cursor-pointer" />
-            </div>
-          ) : (
-            <div className="pt-1" />
-          )}
-          {MOCK_NOTE_DETAIL.content}
-        </div>
-      </div>
+      )}
     </>
   );
 }

--- a/src/components/NoteDetail/index.tsx
+++ b/src/components/NoteDetail/index.tsx
@@ -15,7 +15,7 @@ function NoteDetail({ onClose, noteId }: NoteDetailProps) {
   const [isOpen, setIsOpen] = useState(false);
 
   const { data: noteData } = useGetNote(noteId);
-  const { mutate } = useDeleteNote();
+  const { mutate: deleteNote } = useDeleteNote();
 
   useEffect(() => {
     if (noteData) {
@@ -34,7 +34,7 @@ function NoteDetail({ onClose, noteId }: NoteDetailProps) {
   };
 
   const handleDeleteNote = () => {
-    mutate(noteId);
+    deleteNote(noteId);
   };
 
   return (

--- a/src/components/TodoItem/index.tsx
+++ b/src/components/TodoItem/index.tsx
@@ -143,7 +143,11 @@ function TodoItem({
         <TodoDetailModal todo={todo} onClose={() => setIsModalOpen(false)} />
       )}
       {isNoteDetailOpen && (
-        <NoteDetail onClose={() => setIsNoteDetailOpen(false)} /> // 노트 상세 보기 prop 변경 예정
+        <NoteDetail
+          onClose={() => setIsNoteDetailOpen(false)}
+          // 예외처리 필요합니당.
+          noteId={todo.noteId ? todo.noteId : 0}
+        /> // 노트 상세 보기 prop 변경 예정
       )}
     </>
   );

--- a/src/hooks/api/notesAPI/useDeleteNote.ts
+++ b/src/hooks/api/notesAPI/useDeleteNote.ts
@@ -1,0 +1,12 @@
+import notesAPI from '@app/api/notesAPI';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+const useDeleteNote = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (noteId: number) => notesAPI.deleteNote(noteId),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ['notes'] }),
+  });
+};
+
+export default useDeleteNote;

--- a/src/pages/Notes/components/NoteList/NoteItem.tsx
+++ b/src/pages/Notes/components/NoteList/NoteItem.tsx
@@ -11,7 +11,7 @@ interface NoteItemProps {
 
 function NoteItem({ noteData }: NoteItemProps) {
   const [isDetailOpen, setIsDetailOpen] = useState(false);
-  const { mutate } = useDeleteNote();
+  const { mutate: deleteNote } = useDeleteNote();
   const handleClickNote = () => {
     setIsDetailOpen(true);
   };
@@ -25,7 +25,7 @@ function NoteItem({ noteData }: NoteItemProps) {
   };
 
   const handleDeleteNote = () => {
-    mutate(noteData.id);
+    deleteNote(noteData.id);
   };
 
   return (

--- a/src/pages/Notes/components/NoteList/NoteItem.tsx
+++ b/src/pages/Notes/components/NoteList/NoteItem.tsx
@@ -2,6 +2,7 @@ import { Note } from '@/types/interface';
 import { NoteListIcon } from '@assets';
 import Kebab from '@components/Kebab';
 import NoteDetail from '@components/NoteDetail';
+import useDeleteNote from '@hooks/api/notesAPI/useDeleteNote';
 import { useState } from 'react';
 
 interface NoteItemProps {
@@ -10,7 +11,7 @@ interface NoteItemProps {
 
 function NoteItem({ noteData }: NoteItemProps) {
   const [isDetailOpen, setIsDetailOpen] = useState(false);
-
+  const { mutate } = useDeleteNote();
   const handleClickNote = () => {
     setIsDetailOpen(true);
   };
@@ -24,7 +25,7 @@ function NoteItem({ noteData }: NoteItemProps) {
   };
 
   const handleDeleteNote = () => {
-    // 노트 아이디를 통해 식제
+    mutate(noteData.id);
   };
 
   return (
@@ -53,7 +54,9 @@ function NoteItem({ noteData }: NoteItemProps) {
           </p>
         </div>
       </div>
-      {isDetailOpen && <NoteDetail onClose={handleCloseNote} />}
+      {isDetailOpen && (
+        <NoteDetail onClose={handleCloseNote} noteId={noteData.id} />
+      )}
     </>
   );
 }

--- a/src/pages/Notes/components/NoteList/index.tsx
+++ b/src/pages/Notes/components/NoteList/index.tsx
@@ -1,44 +1,18 @@
+import useGetNotes from '@hooks/api/notesAPI/useGetNotes';
 import NoteItem from './NoteItem';
 
-const MOCK_NOTE = [
-  {
-    todo: {
-      done: true,
-      title: '자바스크립트 기초1 듣기',
-      id: 0,
-    },
-    updatedAt: '2024-07-25T05:01:17.918Z',
-    createdAt: '2024-07-25T05:01:17.918Z',
-    title: '자바스크립트 시작 전 준비물',
-    id: 0,
-    goal: {
-      title: '자바스크립트로 웹 사이트 만들기',
-      id: 0,
-    },
-  },
-  {
-    todo: {
-      done: false,
-      title: '자바스크립트 기초2 듣기',
-      id: 0,
-    },
-    updatedAt: '2024-07-25T05:01:17.918Z',
-    createdAt: '2024-07-25T05:01:17.918Z',
-    title: '자바스크립트',
-    id: 1,
-    goal: {
-      title: '자바스크립트로 웹 사이트 만들기',
-      id: 0,
-    },
-  },
-];
-
 function NoteList() {
+  // 나중에 goalId를 동적으로 받아올 수 있도록 수정
+  const goalId = 250;
+  const { data } = useGetNotes(goalId);
+  // 인피니트 쿼리로 받은 데이터를 플랫하게 펼치기
+  const notes = data?.pages.flatMap((page) => page.data.notes);
+
   return (
     <>
-      {MOCK_NOTE.length > 0 ? (
+      {notes && notes.length > 0 ? (
         <div className="flex flex-col gap-4">
-          {MOCK_NOTE.map((item) => (
+          {notes.map((item) => (
             <NoteItem key={item.id} noteData={item} />
           ))}
         </div>


### PR DESCRIPTION
## 💻 작업 개요

<!--
ex) 구글 소셜 로그인 기능 추가
-->

- 노트 목록, 상세 API 연결

## 💡 변경 사항 (PR 내용)

<!--
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
-->

- 공통 변경 사항
  - 배경색을 App.tsx에서 dvh,dvw 로 주니 스크롤이 내려갔을 때 적용되지 않는 문제가 있어 body의 배경색을 바꾸는 것으로 변경하였습니다.
  - 케밥 컴포넌트의 수정, 삭제 버튼의 전파를 막았습니다.
- 그 외
  - 노트 모아보기, 노트 상세, 케밥의 삭제 API 연결하였습니다. (무한스크롤, 케밥의 수정 부분만 구현하시면 될 것 같습니다.)
  - 노트 상세보기 모달의 백그라운드가 스크롤 내렸을 때 끊겨있는 문제가 있어 fixed로 변경하여 고쳤습니다.

## 🧐 참고 사항

<!--
리뷰 시 유의할 점, 생각해볼 문제
-->

-

## 🖼️ 스크린샷

<!--
스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수 있습니다. 스크린샷을 권장합니다.
![image](경로)
-->

## ️✅ 체크리스트 (PR 올리기 전 아래 내용을 확인해 주세요)

- [x] Reviewers를 지정해주세요
- [x] Assignees는 본인을 선택해주세요
- [x] label을 선택해주세요
