### PR TITLE
[Kan-58] Feature: note list 페이지 infinite scroll, api 연결

### DIFF
--- a/src/components/NoteDetail/index.tsx
+++ b/src/components/NoteDetail/index.tsx
@@ -2,7 +2,6 @@
 
 import { CircleDeleteIcon, DeleteIcon, FlagIcon } from '@assets';
 import Kebab from '@components/Kebab';
-import { showToast } from '@components/Toast';
 import useDeleteNote from '@hooks/api/notesAPI/useDeleteNote';
 import useGetNote from '@hooks/api/notesAPI/useGetNote';
 import formatDate from '@utils/formatDate';
@@ -50,12 +49,7 @@ function NoteDetail({ onClose, noteId }: NoteDetailProps) {
   };
 
   const handleDeleteNote = () => {
-    deleteNoteMutate(noteId, {
-      onSuccess: () => {
-        showToast('노트가 삭제되었습니다');
-        handleClose();
-      },
-    });
+    deleteNoteMutate(noteId);
   };
 
   return (

--- a/src/components/NoteDetail/index.tsx
+++ b/src/components/NoteDetail/index.tsx
@@ -31,7 +31,7 @@ function NoteDetail({ onClose, noteId }: NoteDetailProps) {
 
   const handleClose = () => {
     setIsOpen(false);
-    setTimeout(onClose, 300); // 애니메이션이 끝난 후 onClose 호출
+    setTimeout(onClose, 300);
   };
 
   const handleEditNote = () => {
@@ -46,13 +46,7 @@ function NoteDetail({ onClose, noteId }: NoteDetailProps) {
       id: noteData?.data.todo.id,
     };
 
-    const note = {
-      title: noteData?.data.title,
-      content: noteData?.data.content,
-      linkUrl: noteData?.data.linkUrl,
-    };
-
-    navigate('/notes/new', { state: { todo, note } });
+    navigate('/notes/new', { state: { todo, isEditing: true } });
   };
 
   const handleDeleteNote = () => {

--- a/src/hooks/api/goalsAPI/useGetGoal.ts
+++ b/src/hooks/api/goalsAPI/useGetGoal.ts
@@ -1,0 +1,10 @@
+import goalsAPI from '@app/api/goalsAPI';
+import { useQuery } from '@tanstack/react-query';
+
+const useGetGoal = (goalId: number) =>
+  useQuery({
+    queryKey: ['goal', goalId],
+    queryFn: () => goalsAPI.getGoal(goalId),
+  });
+
+export default useGetGoal;

--- a/src/hooks/api/notesAPI/useDeleteNote.ts
+++ b/src/hooks/api/notesAPI/useDeleteNote.ts
@@ -1,4 +1,5 @@
 import notesAPI from '@app/api/notesAPI';
+import { showToast } from '@components/Toast';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 const useDeleteNote = () => {
@@ -8,6 +9,9 @@ const useDeleteNote = () => {
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['notes'] });
       queryClient.invalidateQueries({ queryKey: ['todos'] });
+    },
+    onSuccess: () => {
+      showToast('노트가 삭제되었습니다');
     },
   });
 };

--- a/src/hooks/api/notesAPI/useDeleteNote.ts
+++ b/src/hooks/api/notesAPI/useDeleteNote.ts
@@ -6,11 +6,9 @@ const useDeleteNote = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (noteId: number) => notesAPI.deleteNote(noteId),
-    onSettled: () => {
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['notes'] });
       queryClient.invalidateQueries({ queryKey: ['todos'] });
-    },
-    onSuccess: () => {
       showToast('노트가 삭제되었습니다');
     },
   });

--- a/src/hooks/api/notesAPI/useGetNote.ts
+++ b/src/hooks/api/notesAPI/useGetNote.ts
@@ -1,10 +1,11 @@
 import notesAPI from '@/api/notesAPI';
 import { useQuery } from '@tanstack/react-query';
 
-const useGetNote = (noteId: number) =>
+const useGetNote = (noteId: number, isEditing = false) =>
   useQuery({
     queryKey: ['note', noteId],
     queryFn: () => notesAPI.getNote(noteId),
+    enabled: isEditing !== undefined && typeof noteId === 'number',
   });
 
 export default useGetNote;

--- a/src/hooks/api/notesAPI/useGetNotes.ts
+++ b/src/hooks/api/notesAPI/useGetNotes.ts
@@ -1,7 +1,7 @@
 import notesAPI from '@/api/notesAPI';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
-const useGetNotes = (goalId?: number, size = 20) =>
+const useGetNotes = (goalId?: number, size = 5) =>
   useInfiniteQuery({
     queryKey: ['notes', goalId, size],
     queryFn: ({ pageParam }) => notesAPI.getNotes(goalId, pageParam, size),

--- a/src/hooks/api/notesAPI/usePatchNote.ts
+++ b/src/hooks/api/notesAPI/usePatchNote.ts
@@ -1,5 +1,6 @@
 import { UpdateNote } from '@/types/interface';
 import notesAPI from '@app/api/notesAPI';
+import { showToast } from '@components/Toast';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 const usePatchNote = () => {
@@ -7,7 +8,10 @@ const usePatchNote = () => {
   return useMutation({
     mutationFn: ({ noteId, note }: { noteId: number; note: UpdateNote }) =>
       notesAPI.patchNote(noteId, note),
-    onSettled: () => queryClient.invalidateQueries({ queryKey: ['notes'] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['notes'] });
+      showToast('노트 수정이 완료되었습니다');
+    },
   });
 };
 

--- a/src/hooks/api/notesAPI/usePostNote.ts
+++ b/src/hooks/api/notesAPI/usePostNote.ts
@@ -1,5 +1,6 @@
 import { CreateNote } from '@/types/interface';
 import notesAPI from '@app/api/notesAPI';
+import { showToast } from '@components/Toast';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 const usePostNote = () => {
@@ -7,7 +8,10 @@ const usePostNote = () => {
   return useMutation({
     mutationFn: ({ todoId, note }: { todoId: number; note: CreateNote }) =>
       notesAPI.postNote(todoId, note),
-    onSettled: () => queryClient.invalidateQueries({ queryKey: ['notes'] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['notes'] });
+      showToast('노트 작성이 완료되었습니다');
+    },
   });
 };
 

--- a/src/pages/NewNote/index.tsx
+++ b/src/pages/NewNote/index.tsx
@@ -1,8 +1,10 @@
-import { NoteDraft } from '@/types/interface';
-import usePatchNote from '@hooks/api/notesAPI/usePatchNote';
-import usePostNote from '@hooks/api/notesAPI/usePostNote';
 import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+
+import { NoteDraft } from '@/types/interface';
+import useGetNote from '@hooks/api/notesAPI/useGetNote';
+import usePatchNote from '@hooks/api/notesAPI/usePatchNote';
+import usePostNote from '@hooks/api/notesAPI/usePostNote';
 
 import Popup from '@components/Popup';
 import { showToast } from '@components/Toast';
@@ -19,19 +21,39 @@ const AUTO_SAVE_INTERVAL = 1000 * 60 * 5;
 
 function NewNotePage() {
   const location = useLocation();
-  const { todo, note: prevNote } = location.state;
-  const [title, setTitle] = useState(prevNote?.title || '');
-  const [content, setContent] = useState(prevNote?.content || '');
-  const [linkUrl, setLinkUrl] = useState(prevNote?.linkUrl || '');
+  const { todo, isEditing } = location.state;
+
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [linkUrl, setLinkUrl] = useState('');
   const [titleCount, setTitleCount] = useState(0);
   const [contentWithSpaces, setContentWithSpaces] = useState(0);
   const [contentWithoutSpaces, setContentWithoutSpaces] = useState(0);
+  const [isSubmitEnabled, setIsSubmitEnabled] = useState(false);
+
+  const { data: noteData } = isEditing
+    ? useGetNote(todo.noteId)
+    : { data: null };
+
+  useEffect(() => {
+    if (isEditing && noteData) {
+      const prevTitle = noteData?.data.title;
+      const prevContent = noteData?.data.content;
+      const prevLinkUrl = noteData?.data.linkUrl;
+
+      setTitle(prevTitle);
+      setContent(prevContent);
+      setLinkUrl(prevLinkUrl);
+      setTitleCount(prevTitle.length);
+      setContentWithSpaces(prevContent.length);
+      setContentWithoutSpaces(prevContent.replace(/\s/g, '').length);
+    }
+  }, [isEditing, noteData]);
 
   const [isDraftExist, setIsDraftExist] = useState(false);
   const [isDraftModalOpen, setIsDraftModalOpen] = useState(false);
   const [draftTitle, setDraftTitle] = useState('');
   const [isDraftSaved, setIsDraftSaved] = useState(false);
-  const [isSubmitEnabled, setIsSubmitEnabled] = useState(false);
   const [isLinkEmbedOpen, setIsLinkEmbedOpen] = useState(false);
 
   const { mutate: createNoteMutate } = usePostNote();
@@ -57,23 +79,15 @@ function NewNotePage() {
     setIsSubmitEnabled(title.trim().length > 0 && content.trim().length > 0);
   }, [title, content, linkUrl]);
 
-  useEffect(() => {
-    if (prevNote) {
-      setTitleCount(prevNote.title.length);
-      setContentWithSpaces(prevNote.content.length);
-      setContentWithoutSpaces(prevNote.content.replace(/\s/g, '').length);
-    }
-  }, [prevNote]);
-
   const handleChangeLink = (newLink: string) => {
     setLinkUrl(newLink);
   };
 
-  const handleChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
-    const { value } = e.target;
-    if (value.length <= TITLE_MAX_LENGTH) {
-      setTitle(value);
-      setTitleCount(value.length);
+  const handleChangeTitle = (e: ChangeEvent<HTMLInputElement>) => {
+    const { value: newTitle } = e.target;
+    if (newTitle.length <= TITLE_MAX_LENGTH) {
+      setTitle(newTitle);
+      setTitleCount(newTitle.length);
     }
   };
 
@@ -198,11 +212,11 @@ function NewNotePage() {
         <div className="mx-4 h-screen w-full max-w-[792px] desktop:ml-[360px]">
           <div className="flex h-screen flex-col bg-white">
             <Header
-              isEditing={prevNote}
+              isEditing={isEditing}
               isSubmitEnabled={isSubmitEnabled}
               onClickDraftButton={handleSaveDraft}
               onClickSaveButton={
-                prevNote ? handleClickEditButton : handleClickSaveButton
+                isEditing ? handleClickEditButton : handleClickSaveButton
               }
             />
             {isDraftExist && (
@@ -218,7 +232,7 @@ function NewNotePage() {
             />
             <TitleInput
               title={title}
-              onChange={handleChangeInput}
+              onChange={handleChangeTitle}
               titleCount={titleCount}
               maxLength={TITLE_MAX_LENGTH}
             />

--- a/src/pages/NewNote/index.tsx
+++ b/src/pages/NewNote/index.tsx
@@ -7,7 +7,6 @@ import usePatchNote from '@hooks/api/notesAPI/usePatchNote';
 import usePostNote from '@hooks/api/notesAPI/usePostNote';
 
 import Popup from '@components/Popup';
-import { showToast } from '@components/Toast';
 import DraftNotification from './components/DraftNotification';
 import DraftSavedToast from './components/DraftSavedToast';
 import Header from './components/Header';
@@ -31,9 +30,7 @@ function NewNotePage() {
   const [contentWithoutSpaces, setContentWithoutSpaces] = useState(0);
   const [isSubmitEnabled, setIsSubmitEnabled] = useState(false);
 
-  const { data: noteData } = isEditing
-    ? useGetNote(todo.noteId)
-    : { data: null };
+  const { data: noteData } = useGetNote(todo.noteId, isEditing);
 
   useEffect(() => {
     if (isEditing && noteData) {
@@ -156,7 +153,6 @@ function NewNotePage() {
       {
         onSuccess: () => {
           handleDeleteDraft(todo.id);
-          showToast('노트 작성이 완료되었습니다');
           navigate(-1);
         },
       },
@@ -176,7 +172,6 @@ function NewNotePage() {
       {
         onSuccess: () => {
           handleDeleteDraft(todo.id);
-          showToast('노트 수정이 완료되었습니다');
           navigate(-1);
         },
       },

--- a/src/pages/Notes/components/NoteList/NoteItem.tsx
+++ b/src/pages/Notes/components/NoteList/NoteItem.tsx
@@ -2,7 +2,6 @@ import { Note } from '@/types/interface';
 import { NoteListIcon } from '@assets';
 import Kebab from '@components/Kebab';
 import NoteDetail from '@components/NoteDetail';
-import { showToast } from '@components/Toast';
 import useDeleteNote from '@hooks/api/notesAPI/useDeleteNote';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -40,11 +39,7 @@ function NoteItem({ noteData }: NoteItemProps) {
   };
 
   const handleDeleteNote = () => {
-    deleteNoteMutate(noteData.id, {
-      onSuccess: () => {
-        showToast('노트가 삭제되었습니다');
-      },
-    });
+    deleteNoteMutate(noteData.id);
   };
 
   return (

--- a/src/pages/Notes/components/NoteList/NoteItem.tsx
+++ b/src/pages/Notes/components/NoteList/NoteItem.tsx
@@ -2,8 +2,10 @@ import { Note } from '@/types/interface';
 import { NoteListIcon } from '@assets';
 import Kebab from '@components/Kebab';
 import NoteDetail from '@components/NoteDetail';
+import { showToast } from '@components/Toast';
 import useDeleteNote from '@hooks/api/notesAPI/useDeleteNote';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 interface NoteItemProps {
   noteData: Note;
@@ -11,7 +13,9 @@ interface NoteItemProps {
 
 function NoteItem({ noteData }: NoteItemProps) {
   const [isDetailOpen, setIsDetailOpen] = useState(false);
-  const { mutate: deleteNote } = useDeleteNote();
+  const { mutate: deleteNoteMutate } = useDeleteNote();
+  const navigate = useNavigate();
+
   const handleClickNote = () => {
     setIsDetailOpen(true);
   };
@@ -21,11 +25,26 @@ function NoteItem({ noteData }: NoteItemProps) {
   };
 
   const handleEditNote = () => {
-    // 노트 아이디를 통해 수정
+    const todo = {
+      noteId: noteData.id,
+      done: noteData.todo.done,
+      title: noteData.todo.title,
+      goal: {
+        id: noteData.goal.id || null,
+        title: noteData.goal.title || null,
+      },
+      id: noteData.todo.id,
+    };
+
+    navigate('/notes/new', { state: { todo, isEditing: true } });
   };
 
   const handleDeleteNote = () => {
-    deleteNote(noteData.id);
+    deleteNoteMutate(noteData.id, {
+      onSuccess: () => {
+        showToast('노트가 삭제되었습니다');
+      },
+    });
   };
 
   return (

--- a/src/pages/Notes/components/NoteList/index.tsx
+++ b/src/pages/Notes/components/NoteList/index.tsx
@@ -1,12 +1,33 @@
+import LoadingAnimation from '@components/LoadingAnimation';
 import useGetNotes from '@hooks/api/notesAPI/useGetNotes';
+import { useEffect } from 'react';
+import { useInView } from 'react-intersection-observer';
 import NoteItem from './NoteItem';
 
-function NoteList() {
-  // 나중에 goalId를 동적으로 받아올 수 있도록 수정
-  const goalId = 250;
-  const { data } = useGetNotes(goalId);
+interface NoteListProps {
+  goalId: number;
+}
+
+function NoteList({ goalId }: NoteListProps) {
+  const { data, fetchNextPage, hasNextPage, isLoading } = useGetNotes(goalId);
+  const { ref: intersectionRef, inView } = useInView();
+
+  useEffect(() => {
+    if (inView && hasNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, fetchNextPage, hasNextPage]);
+
   // 인피니트 쿼리로 받은 데이터를 플랫하게 펼치기
   const notes = data?.pages.flatMap((page) => page.data.notes);
+
+  if (isLoading) {
+    return (
+      <div className="mt-60 flex items-center justify-center">
+        <LoadingAnimation />
+      </div>
+    );
+  }
 
   return (
     <>
@@ -15,6 +36,7 @@ function NoteList() {
           {notes.map((item) => (
             <NoteItem key={item.id} noteData={item} />
           ))}
+          <div ref={intersectionRef} />
         </div>
       ) : (
         <div className="mt-[30vh] flex max-w-[792px] items-center justify-center text-lg leading-5 text-slate-500">

--- a/src/pages/Notes/index.tsx
+++ b/src/pages/Notes/index.tsx
@@ -1,7 +1,12 @@
 import { FlagIcon } from '@assets';
+import useGetGoal from '@hooks/api/goalsAPI/useGetGoal';
+import { useParams } from 'react-router-dom';
 import NoteList from './components/NoteList';
 
 function NotesPage() {
+  const { goalId } = useParams();
+  const { data: goalData } = useGetGoal(Number(goalId));
+
   return (
     <div className="flex items-center justify-center desktop:block">
       <div className="mx-4 w-full max-w-[792px] desktop:ml-[360px]">
@@ -13,10 +18,10 @@ function NotesPage() {
             <FlagIcon className="h-[14.4px] w-[14.4px] fill-white" />
           </div>
           <h2 className="text-sm font-semibold leading-5 text-slate-800">
-            자바스크립트로 웹 서비스 만들기
+            {goalData?.data.title}
           </h2>
         </div>
-        <NoteList />
+        <NoteList goalId={Number(goalId)} />
       </div>
     </div>
   );

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -31,7 +31,7 @@ const router = createBrowserRouter([
         element: <GoalDetailPage />,
       },
       {
-        path: routes.notes,
+        path: `${routes.notes}/:goalId`,
         element: <NotesPage />,
       },
       {


### PR DESCRIPTION
## 💻 작업 개요

<!--
ex) 구글 소셜 로그인 기능 추가
-->

- 노트 리스트 페이지 api 연결
- 노트 리스트 페이지 동적라우팅 적용

## 💡 변경 사항 (PR 내용)

<!--
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
-->

- 노트 수정 시 note detail api 이용해 정보 가져오도록 수정
- 노트 리스트 무한스크롤 구현
- api 훅들 onSettled -> onSuccess로 변경

## 🧐 참고 사항

<!--
리뷰 시 유의할 점, 생각해볼 문제
-->

- useGetGoal 임시로 작성(주현님꺼 있으시면 따라가겠습니다!)

## 🖼️ 스크린샷

<!--
스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수 있습니다. 스크린샷을 권장합니다.
![image](경로)
-->

## ️✅ 체크리스트 (PR 올리기 전 아래 내용을 확인해 주세요)

- [x] Reviewers를 지정해주세요
- [x] Assignees는 본인을 선택해주세요
- [x] label을 선택해주세요
