### PR TITLE
[Kan-83] Refactor: 사이드바 리팩토링

### DIFF
--- a/src/components/SideBar/DesktopSideBarContents.tsx
+++ b/src/components/SideBar/DesktopSideBarContents.tsx
@@ -135,6 +135,7 @@ function DesktopSideBarContents({
                 if (event.key === 'Enter') {
                   setIsEditing(false);
                   mutate(newGoal);
+                  setNewGoal('');
                 }
               }}
             />

--- a/src/components/SideBar/DesktopSideBarContents.tsx
+++ b/src/components/SideBar/DesktopSideBarContents.tsx
@@ -8,7 +8,7 @@ import {
 import Button from '@components/Button';
 import usePostGoal from '@hooks/api/goalsAPI/usePostGoal';
 import useOutsideClick from '@hooks/useOutsideClick';
-import { MouseEvent, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 interface DesktopSideBarContentsProps {
@@ -32,9 +32,8 @@ function DesktopSideBarContents({
   const navigate = useNavigate();
   useOutsideClick(inputRef, () => setIsEditing(false));
 
-  const handleAddGoalBtn = (e: MouseEvent) => {
-    e.stopPropagation();
-    setIsEditing(true);
+  const handleAddGoalBtn = () => {
+    setTimeout(() => setIsEditing(true), 0);
   };
 
   useEffect(() => {
@@ -111,11 +110,9 @@ function DesktopSideBarContents({
               navigate('/goal-detail');
               if (width < 1920) toggleSideBar();
             }}
+            key={item.id}
           >
-            <li
-              key={item.id}
-              className="cursor-pointer p-2 text-sm font-medium text-slate-700"
-            >
+            <li className="cursor-pointer p-2 text-sm font-medium text-slate-700">
               • {item.title}
             </li>
           </div>
@@ -150,7 +147,7 @@ function DesktopSideBarContents({
           shape="outlined"
           size="sm"
           additionalClass="w-full"
-          onClick={(e) => handleAddGoalBtn(e)}
+          onClick={handleAddGoalBtn}
           disabled={isEditing}
         >
           <PlusIcon

--- a/src/components/SideBar/MobileSideBarContents.tsx
+++ b/src/components/SideBar/MobileSideBarContents.tsx
@@ -8,7 +8,7 @@ import {
 import Button from '@components/Button';
 import usePostGoal from '@hooks/api/goalsAPI/usePostGoal';
 import useOutsideClick from '@hooks/useOutsideClick';
-import { MouseEvent, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 interface MobileSideBarContentsProps {
@@ -31,9 +31,8 @@ function MobileSideBarContents({
 
   useOutsideClick(inputRef, () => setIsEditing(false));
 
-  const handleAddGoalBtn = (e: MouseEvent) => {
-    e.stopPropagation();
-    setIsEditing(true);
+  const handleAddGoalBtn = () => {
+    setTimeout(() => setIsEditing(true), 0);
   };
 
   useEffect(() => {
@@ -112,7 +111,7 @@ function MobileSideBarContents({
         <Button
           shape="outlined"
           size="xs"
-          onClick={(e) => handleAddGoalBtn(e)}
+          onClick={handleAddGoalBtn}
           disabled={isEditing}
         >
           <PlusIcon
@@ -130,11 +129,9 @@ function MobileSideBarContents({
               navigate('/goal-detail');
               toggleSideBar();
             }}
+            key={item.id}
           >
-            <li
-              key={item.id}
-              className="cursor-pointer p-2 text-sm font-medium text-slate-700"
-            >
+            <li className="cursor-pointer p-2 text-sm font-medium text-slate-700">
               • {item.title}
             </li>
           </div>


### PR DESCRIPTION
## 💻 작업 개요

<!--
ex) 구글 소셜 로그인 기능 추가
-->

- 사이드바 리팩토링

## 💡 변경 사항 (PR 내용)

<!--
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
-->

- 새목표 버튼 클릭 시 이벤트가 전파되어 useOutsideClick이 인풋 창을 닫아버리는 문제가 있었습니다. 기존에는 이 문제를 새목표 버튼의 이벤트 전파를 막는것으로 해결하였는데 멘토님 조언에 따라 setTimeout으로 해결하였습니다.

**setTimeout으로 해결할 수 있는 이유.**
- setTimeout은 태스크 큐에서 실행되기 때문에 실행 순서가 뒤로 미뤄집니다.

**궁금했던 점**

- **UI 이벤트도 태스크 큐에서 실행된다고 하는데 setTimeout으로 한다고 했을 때 둘 사이의 실행 순서가 보장되는가?**

  찾아보니 대부분의 브라우저는 UI 이벤트를 처리하는 고유의 태스크 큐가 있고 보통 높은 우선 순위를 가지고 있다고 합니다. 또한 반대로 setTimeout과 같은 타이머를 처리하는 고유의 태스크 큐가 있고 이는 보통 낮은 우선 순위를 가지고 있다고 합니다. 따라서 UI 이벤트와 setTimeout은 서로 다른 태스크 큐에서 실행되고 대부분 UI 이벤트가 더 우선순위가 높습니다. (https://stackoverflow.com/questions/64762059/which-tasksettimeout-or-click-event-is-prioritized-in-the-task-queue)


## 🧐 참고 사항

<!--
리뷰 시 유의할 점, 생각해볼 문제
-->

-

## 🖼️ 스크린샷

<!--
스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수 있습니다. 스크린샷을 권장합니다.
![image](경로)
-->

## ️✅ 체크리스트 (PR 올리기 전 아래 내용을 확인해 주세요)

- [x] Reviewers를 지정해주세요
- [x] Assignees는 본인을 선택해주세요
- [x] label을 선택해주세요
