### PR TITLE
Feature: 쿼리 클라이언트 위치 변경, 에러 처리 로직 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "framer-motion": "^11.3.21",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-error-boundary": "^4.0.13",
         "react-hook-form": "^7.52.1",
         "react-infinite-scroller": "^1.2.6",
         "react-intersection-observer": "^9.13.0",
@@ -25376,6 +25377,17 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
       "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
       "dev": true
+    },
+    "node_modules/react-error-boundary": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.13.tgz",
+      "integrity": "sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
     },
     "node_modules/react-error-overlay": {
       "version": "6.0.11",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "framer-motion": "^11.3.21",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-error-boundary": "^4.0.13",
     "react-hook-form": "^7.52.1",
     "react-infinite-scroller": "^1.2.6",
     "react-intersection-observer": "^9.13.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import SideBar from '@components/SideBar';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import AppErrorBoundary from '@utils/AppErrorBoundary';
 import { useEffect } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
@@ -8,6 +9,7 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: false,
+      throwOnError: true,
     },
   },
 });
@@ -40,12 +42,14 @@ function App() {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <div className="h-dvh w-dvw max-w-full font-Pretendard text-base font-normal">
-        {pathname !== '/sign-in' && pathname !== '/sign-up' && <SideBar />}
-        <div className="ml-0 tablet:ml-[60px] desktop:ml-0">
-          <Outlet />
+      <AppErrorBoundary>
+        <div className="h-dvh w-dvw max-w-full font-Pretendard text-base font-normal">
+          {pathname !== '/sign-in' && pathname !== '/sign-up' && <SideBar />}
+          <div className="ml-0 tablet:ml-[60px] desktop:ml-0">
+            <Outlet />
+          </div>
         </div>
-      </div>
+      </AppErrorBoundary>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,30 +1,18 @@
 import SideBar from '@components/SideBar';
-import useApiError from '@hooks/api/useApiError';
-import {
-  QueryCache,
-  QueryClient,
-  QueryClientProvider,
-} from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useEffect } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
-function App() {
-  const { handleError } = useApiError();
-
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      mutations: {
-        onError: handleError,
-      },
-      queries: {
-        retry: false,
-      },
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
     },
-    queryCache: new QueryCache({
-      onError: handleError,
-    }),
-  });
+  },
+});
+
+function App() {
   const { pathname } = useLocation();
 
   const bgColor =

--- a/src/utils/AppErrorBoundary.tsx
+++ b/src/utils/AppErrorBoundary.tsx
@@ -1,0 +1,57 @@
+/* eslint-disable */
+
+import { showErrorToast } from '@components/Toast';
+import { isAxiosError } from 'axios';
+import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
+
+function handleFallbackError({ error }: FallbackProps) {
+  return (
+    <div
+      role="alert"
+      className="mt-10 flex flex-col items-center justify-center text-2xl"
+    >
+      <p>{'오류가 발생했습니다. :('}</p>
+      <button
+        type="button"
+        onClick={() => location.reload()}
+        className="underline"
+      >
+        돌아가기
+      </button>
+    </div>
+  );
+}
+
+function AppErrorBoundary({ children }: { children: React.ReactNode }) {
+  const onErrorHandler = (error: Error) => {
+    console.log(error);
+    if (isAxiosError(error)) {
+      if (
+        error.code === 'ERR_CANCELED' ||
+        error.response?.data.message === 'Unauthorized'
+      ) {
+        // location.href = '/sign-in';
+        showErrorToast('로그인이 필요합니다.');
+        return;
+      }
+      if (error.code === 'ERR_BAD_RESPONSE') {
+        console.log('서버에러가 발생');
+        showErrorToast('서버 에러가 발생했습니다.');
+        return;
+      }
+    }
+
+    showErrorToast('알 수 없는 에러가 발생했습니다.');
+    return;
+  };
+  return (
+    <ErrorBoundary
+      FallbackComponent={handleFallbackError}
+      onError={onErrorHandler}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}
+
+export default AppErrorBoundary;

--- a/src/utils/AppErrorBoundary.tsx
+++ b/src/utils/AppErrorBoundary.tsx
@@ -1,19 +1,18 @@
-/* eslint-disable */
-
 import { showErrorToast } from '@components/Toast';
 import { isAxiosError } from 'axios';
-import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
+import { ReactNode } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 
-function handleFallbackError({ error }: FallbackProps) {
+function handleFallbackError() {
   return (
     <div
       role="alert"
       className="mt-10 flex flex-col items-center justify-center text-2xl"
     >
-      <p>{'오류가 발생했습니다. :('}</p>
+      <p>오류가 발생했습니다. :(</p>
       <button
         type="button"
-        onClick={() => location.reload()}
+        onClick={() => window.location.reload()}
         className="underline"
       >
         돌아가기
@@ -22,27 +21,24 @@ function handleFallbackError({ error }: FallbackProps) {
   );
 }
 
-function AppErrorBoundary({ children }: { children: React.ReactNode }) {
+function AppErrorBoundary({ children }: { children: ReactNode }) {
   const onErrorHandler = (error: Error) => {
-    console.log(error);
     if (isAxiosError(error)) {
       if (
         error.code === 'ERR_CANCELED' ||
         error.response?.data.message === 'Unauthorized'
       ) {
-        // location.href = '/sign-in';
+        window.location.href = '/sign-in';
         showErrorToast('로그인이 필요합니다.');
         return;
       }
       if (error.code === 'ERR_BAD_RESPONSE') {
-        console.log('서버에러가 발생');
         showErrorToast('서버 에러가 발생했습니다.');
         return;
       }
     }
 
     showErrorToast('알 수 없는 에러가 발생했습니다.');
-    return;
   };
   return (
     <ErrorBoundary


### PR DESCRIPTION
## 💻 작업 개요

<!--
ex) 구글 소셜 로그인 기능 추가
-->

- 쿼리 클라이언트 위치 변경

## 💡 변경 사항 (PR 내용)

<!--
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
-->

- 함수 안에서 쿼리클라이언트를 선언하여 invalidateQueries 가 제대로 작동하지 않던 문제를 쿼리 클라이언트를 함수 바깥에서 선언하도록 수정하여 고쳤습니다.
- 쿼리 클라이언트가 밖에서 선언되기 때문에 훅으로 에러를 처리하던 기존의 방식을 쓸 수 없어 ErrorBoundary 방식으로 변경하였습니다.
- 리액트에서 제공하는 ErrorBoundary는 클래스형이라 함수형으로 쓸 수 있도록 라이브러리를 설치하였습니다.
- 모든 에러를 ErrorBoundary에서 처리하려고 했는데 그렇게 잘 동작하지 않아서 기존에 axios에서 처리하던 에러는 그대로 두고 훅에서 처리하던 에러들만 ErrorBoundary로 옮겼습니다.

## 🧐 참고 사항

<!--
리뷰 시 유의할 점, 생각해볼 문제
-->

- ErrorBoundary에서 에러를 전역적으로 잡는게 좋은 패턴은 아니라고 합니다. 각 컴포넌트별로 잡아서 에러 발생 시에 해당 컴포넌트만 재렌더링할 수 있는 UI를 보여주는 것이 좋은 방법이지만 현재 잡는 에러는 인증 쪽 밖에 없어서 전역적으로 잡았습니다. (어차피 인증 에러면 모든 컴포넌트가 똑같이 에러나기 때문입니다.)
- 리액트 쿼리에서 에러를 뱉는데 에러 바운더리에서 못 잡는 부분이 있습니다. 이거 진짜 해결하려고 계속 봐도 도저히 뭔지 모르겠어서 포기했습니다 ㅠ 실제 배포환경에서는 문제되지 않을 것 같은데 개발환경에서는 에러 발생시 잠깐 에러창이 떴다가 없어질 것입니다. 이건 공부를 좀 더 하고 고쳐보도록 하겠습니다.
## 🖼️ 스크린샷

<!--
스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수 있습니다. 스크린샷을 권장합니다.
![image](경로)
-->

## ️✅ 체크리스트 (PR 올리기 전 아래 내용을 확인해 주세요)

- [x] Reviewers를 지정해주세요
- [x] Assignees는 본인을 선택해주세요
- [x] label을 선택해주세요
