### PR TITLE
fix: 목표 상세 페이지에서 사이드바 목표 삭제

### DIFF
--- a/src/components/SideBar/DesktopSideBar.tsx
+++ b/src/components/SideBar/DesktopSideBar.tsx
@@ -3,7 +3,7 @@ import Popup from '@components/Popup';
 import TodoCreateModal from '@components/TodoModal/TodoCreateModal';
 import useDeleteGoal from '@hooks/api/goalsAPI/useDeleteGoal';
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import DesktopSideBarContents from './DesktopSideBarContents';
 
 interface SideBarProps {
@@ -27,6 +27,8 @@ function DesktopSideBar({
   userData,
   goalData,
 }: SideBarProps) {
+  const navigate = useNavigate();
+  const location = useLocation();
   const [showTodoModal, setShowTodoModal] = useState(false);
   const [isDeletePopupVisible, setIsDeletePopupVisible] = useState(false);
   const [goalId, setGoalId] = useState<number>(0);
@@ -36,15 +38,18 @@ function DesktopSideBar({
     setIsDeletePopupVisible(true);
     setGoalId(id);
   };
+
   const handleDelete = () => {
     deleteGoalMutate(goalId, {
       onSuccess: () => {
         setIsDeletePopupVisible(false);
+        if (location.pathname === `/goal-detail/${goalId}`) {
+          navigate('/dashboard');
+        }
         setGoalId(0);
       },
     });
   };
-  const navigate = useNavigate();
   return (
     <>
       {isOpen && width < 1920 && (

--- a/src/components/SideBar/DesktopSideBar.tsx
+++ b/src/components/SideBar/DesktopSideBar.tsx
@@ -43,7 +43,10 @@ function DesktopSideBar({
     deleteGoalMutate(goalId, {
       onSuccess: () => {
         setIsDeletePopupVisible(false);
-        if (location.pathname === `/goal-detail/${goalId}`) {
+        if (
+          location.pathname === `/goal-detail/${goalId}` ||
+          location.pathname === `/notes/${goalId}`
+        ) {
           navigate('/dashboard');
         }
         setGoalId(0);

--- a/src/components/SideBar/MobileSideBar.tsx
+++ b/src/components/SideBar/MobileSideBar.tsx
@@ -3,6 +3,7 @@ import Popup from '@components/Popup';
 import TodoCreateModal from '@components/TodoModal/TodoCreateModal';
 import useDeleteGoal from '@hooks/api/goalsAPI/useDeleteGoal';
 import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import MobileSideBarContents from './MobileSideBarContents';
 
 interface MobileSideBarProps {
@@ -18,6 +19,8 @@ function MobileSideBar({
   userData,
   goalData,
 }: MobileSideBarProps) {
+  const navigate = useNavigate();
+  const location = useLocation();
   const [showTodoModal, setShowTodoModal] = useState(false);
   const [isDeletePopupVisible, setIsDeletePopupVisible] = useState(false);
   const [goalId, setGoalId] = useState<number>(0);
@@ -31,6 +34,12 @@ function MobileSideBar({
     deleteGoalMutate(goalId, {
       onSuccess: () => {
         setIsDeletePopupVisible(false);
+        if (
+          location.pathname === `/goal-detail/${goalId}` ||
+          location.pathname === `/notes/${goalId}`
+        ) {
+          navigate('/dashboard');
+        }
         setGoalId(0);
       },
     });


### PR DESCRIPTION
## 💻 작업 개요

<!--
ex) 구글 소셜 로그인 기능 추가
-->

- 목표 상세 페이지에서 사이드바에서 해당 목표 삭제시 대쉬보드 페이지로 이동하도록 변경

## 💡 변경 사항 (PR 내용)

<!--
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
-->

-

## 🧐 참고 사항

<!--
리뷰 시 유의할 점, 생각해볼 문제
-->

-

## 🖼️ 스크린샷

<!--
스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수 있습니다. 스크린샷을 권장합니다.
![image](경로)
-->

## ️✅ 체크리스트 (PR 올리기 전 아래 내용을 확인해 주세요)

- [x] Reviewers를 지정해주세요
- [x] Assignees는 본인을 선택해주세요
- [x] label을 선택해주세요
